### PR TITLE
Configure HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Development requires [python3](https://www.python.org/) and [nodejs](https://nod
 
 ## Deployment
 To deploy the website on a machine running docker run the following commands:
-```
+```bash
 git clone https://github.com/Imageomics/Andromeda.git
 cd Andromeda/
 docker-compose up -d
@@ -18,6 +18,33 @@ The `-d` flag runs the website in the background. For troubleshooting remove thi
 Once the website finishes launching the website will be available on port 80: [http://localhost](http://localhost).
 Part of the deployment builds the docker containers used by the website, so it may take a few minutes to finish deployment.
 To stop the app run `docker-compose down`.
+
+### Certbot Setup on AWS
+Certificates can be installed to the EC2 VM using Certbot with Nginx on pip following [EFF instructions](https://certbot.eff.org/instructions?ws=nginx&os=pip).
+```bash
+sudo python3 -m venv /opt/certbot/
+sudo /opt/certbot/bin/pip install --upgrade pip
+sudo /opt/certbot/bin/pip install certbot certbot-nginx
+sudo ln -s /opt/certbot/bin/certbot /usr/bin/certbot
+```
+And to install Nginx on the Amazon Linux 2023 (following [instructions](https://awswithatiq.com/how-to-install-nginx-in-amazon-linux-2023/)) and run Certbot:
+```bash
+docker-compose down
+sudo dnf update -y
+sudo dnf install nginx -y
+sudo systemctl start nginx
+sudo certbot certonly --nginx
+```
+Following prompted agreements, registration, and specifying andromeda.imageomics.org, the certificates are installed to:
+
+Certifate: `/etc/letsencrypt/live/andromeda.imageomics.org/fullchain.pem`
+Key: `/etc/letsencrypt/live/andromeda.imageomics.org/privkey.pem`
+
+Finally, shut down Nginx on the system to avoid interference with the container:
+```bash
+sudo systemctl stop nginx
+nohup docker-compose up -d &
+```
 
 ## Development
 To run the website locally without using docker requires two terminal sessions.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ sudo certbot certonly --nginx
 ```
 Following prompted agreements, registration, and specifying andromeda.imageomics.org, the certificates are installed to:
 
-Certifate: `/etc/letsencrypt/live/andromeda.imageomics.org/fullchain.pem`
+Certificate: `/etc/letsencrypt/live/andromeda.imageomics.org/fullchain.pem`
+
 Key: `/etc/letsencrypt/live/andromeda.imageomics.org/privkey.pem`
 
 Finally, shut down Nginx on the system to avoid interference with the container:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Key: `/etc/letsencrypt/live/andromeda.imageomics.org/privkey.pem`
 Finally, shut down Nginx on the system to avoid interference with the container:
 ```bash
 sudo systemctl stop nginx
-nohup docker-compose up -d &
+docker-compose up -d
 ```
 
 ## Development

--- a/andromeda-ui/nginx.conf
+++ b/andromeda-ui/nginx.conf
@@ -31,8 +31,18 @@ http {
     #gzip  on;
 
     server {
+        listen 80;
+        server_name andromeda.imageomics.org www.andromeda.imageomics.org;
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+    server {
         listen 443 ssl;
-	server_name andromeda.imageomics.org;
+	server_name andromeda.imageomics.org www.andromeda.imageomics.org;
+
 	ssl_certificate /etc/letsencrypt/live/andromeda.imageomics.org/fullchain.pem;
 	ssl_certificate_key /etc/letsencrypt/live/andromeda.imageomics.org/privkey.pem;
 	

--- a/andromeda-ui/nginx.conf
+++ b/andromeda-ui/nginx.conf
@@ -11,6 +11,8 @@ events {
 
 
 http {
+    ssl_session_cache	shared:SSL:10m;
+    ssl_session_timeout	10m;
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
@@ -29,7 +31,11 @@ http {
     #gzip  on;
 
     server {
-        listen 8080;
+        listen 443 ssl;
+	server_name andromeda.imageomics.org;
+	ssl_certificate /etc/letsencrypt/live/andromeda.imageomics.org/fullchain.pem;
+	ssl_certificate_key /etc/letsencrypt/live/andromeda.imageomics.org/privkey.pem;
+	
         root /data/www;
         location / {
             try_files $uri $uri/ /index.html;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     expose:
       - "8080"
     ports:
-      - "80:8080"
+      - "80:80"
       - "443:443"
     volumes:
       - /etc/letsencrypt:/etc/letsencrypt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,9 @@ services:
       - "8080"
     ports:
       - "80:8080"
+      - "443:443"
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt
 
 networks:
   apinetwork:


### PR DESCRIPTION
Installed certs with certbot into EC2 instance, mounted volume into docker-compose, and configured nginx to use encryption. Forwards http to https.

Auto cert renewal coming in a future issue.

This branch came directly off of `main`, and commits to it were cherry-picked from `https` (which was branched from `15-react`) to select only the relevant HTTPS-related changes.