### PR TITLE
Adds API endpoints to fetch iNaturalist data

### DIFF
--- a/andromeda/README.md
+++ b/andromeda/README.md
@@ -101,3 +101,40 @@ Calculate weights for the given image coordinates.
     }
     ```
 
+### Fetch iNaturalist observations as JSON data
+Read all observations for iNaturalist user and return as JSON.
+- GET __/api/inaturalist/<inat_user>__
+  - Output
+    ```  
+    {
+      "data": [
+        {
+          "Date": "...",
+          "Image_Label": "...",
+          "Image_Link": "...",
+          "Lat": 42.9349293461,
+          "Long": -88.0380119262,
+          "Place": "...",
+          "Seconds": 57785,
+          "Species": "White-tailed Deer",
+          "Time": "...",
+          "User": "..."
+        },
+        ...
+      "user_id": "...",
+      "warnings": [
+        "missing_lat_long"
+      ]
+    }
+    ```
+
+### Fetch iNaturalist observations as CSV data
+Read all observations for iNaturalist user and return as a CSV file.
+- GET __/api/inaturalist/<inat_user>?format=csv__
+  - Output
+    ```  
+    Image_Label,Image_Link,Species,User,Date,Time,Seconds,Place,Lat,Long
+    p1,https://static.inaturalist.org/photos/12647253/medium.jpg,White-tailed Deer,lhouse,2017-12-31,16:03:05,57785,"Whitnall Park, Hales Corners, WI, US",42.9349293461,-88.0380119262
+    ...
+    ```
+NOTE: Since the result is a CSV file no warnings will be returned.

--- a/andromeda/inaturalist.py
+++ b/andromeda/inaturalist.py
@@ -1,0 +1,89 @@
+import io
+import csv
+import pandas as pd
+from pyinaturalist import get_observations
+
+LABEL_FIELD = "Image_Label"
+URL_FIELD = "Image_Link"
+SPECIES_FIELD = "Species"
+USER_FIELD = "User"
+DATE_FIELD = "Date"
+TIME_FIELD = "Time"
+SECONDS_FIELD = "Seconds"
+PLACE_FIELD = "Place"
+LAT_FIELD = "Lat"
+LON_FIELD = "Long"
+CSV_FIELDS = [
+    LABEL_FIELD,
+    URL_FIELD,
+    SPECIES_FIELD,
+    USER_FIELD,
+    DATE_FIELD,
+    TIME_FIELD,
+    SECONDS_FIELD,
+    PLACE_FIELD,
+    LAT_FIELD,
+    LON_FIELD,
+]
+
+
+def get_inaturalist_observations(user_id):
+    result = []
+    idx = 0
+    missing_lat_long = False
+    observations = get_observations(user_id=user_id, page="all")
+    for obs in observations["results"]:
+        idx += 1
+        label = f"p{idx}"
+        df = pd.DataFrame.from_dict(obs, orient="index")
+        # Get image urls
+        if obs.get("photos"):
+            # Replace image size from 'square' to 'medium' and 'large'
+            image_url = obs.get("photos")[0].get("url").replace("square", "medium")
+        else:
+            image_url = None
+        observed_on = pd.to_datetime(obs.get("observed_on"))
+        observed_seconds = (
+            observed_on.hour * 3600 + observed_on.minute * 60 + observed_on.second
+        )
+        if obs.get("location"):
+            lat = obs.get("location")[0]
+            lon = obs.get("location")[1]
+        else:
+            lat = None
+            lon = None
+        place_guess = obs.get("place_guess")
+        user_login = obs.get("user", {}).get("login")
+        if not lat or not lon:
+            missing_lat_long = True
+        result.append(
+            {
+                LABEL_FIELD: label,
+                URL_FIELD: image_url,
+                SPECIES_FIELD: obs.get("species_guess"),
+                USER_FIELD: user_login,
+                DATE_FIELD: observed_on.strftime("%Y-%m-%d"),
+                TIME_FIELD: observed_on.strftime("%H:%M:%S"),
+                SECONDS_FIELD: observed_seconds,
+                PLACE_FIELD: place_guess,
+                LAT_FIELD: lat,
+                LON_FIELD: lon,
+            }
+        )
+    warnings = []
+    if missing_lat_long:
+        warnings.append("missing_lat_long")
+    return result, warnings
+
+
+def get_inaturalist_fieldnames():
+    return CSV_FIELDS[:]
+
+
+def create_csv_str(fieldnames, observations):
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=fieldnames, lineterminator="\n")
+    writer.writeheader()
+    for obs in observations:
+        writer.writerow(obs)
+    return output.getvalue()

--- a/andromeda/itest.sh
+++ b/andromeda/itest.sh
@@ -25,4 +25,11 @@ curl -X POST -H "Content-Type: application/json" \
     -d '{"images": [ { "label": "p1", "x": 0.5920513794381642, "y": -0.009178126747895218 }, { "label": "p2", "x": -0.4686290075683762, "y": -0.34844575009740675 } ], "columnSettings": {"label":"Image_Label","selected":["R1","G1","B1"]}}' \
     http://127.0.0.1:5000/api/dataset/$ID/inverse-dimensional-reduction
 
+echo "Fetching inaturalist observations"
+curl http://127.0.0.1:5000/api/inaturalist/lhouse
+
+echo "Fetching inaturalist observations as CSV"
+curl http://127.0.0.1:5000/api/inaturalist/lhouse?format=csv
+
+echo ""
 echo "Done"

--- a/andromeda/requirements.txt
+++ b/andromeda/requirements.txt
@@ -2,3 +2,4 @@ pandas==2.0.0
 scikit-learn==1.2.2
 Flask==2.3.2
 Flask-Cors==3.0.10
+pyinaturalist==0.18.0

--- a/andromeda/tests/test_inaturalist.py
+++ b/andromeda/tests/test_inaturalist.py
@@ -1,0 +1,93 @@
+import unittest
+import datetime
+from unittest.mock import patch
+from inaturalist import (
+    get_inaturalist_fieldnames,
+    get_inaturalist_observations,
+    create_csv_str,
+)
+
+
+class TestINaturalist(unittest.TestCase):
+    @patch("inaturalist.get_observations")
+    def test_get_inaturalist_observations(self, mock_get_observations):
+        expected_columns = [
+            "Image_Label",
+            "Image_Link",
+            "Species",
+            "User",
+            "Date",
+            "Time",
+            "Seconds",
+            "Place",
+            "Lat",
+            "Long",
+        ]
+        item = {
+            "photos": [{"url": "https://example.com/p1_square.png"}],
+            "p1": ["ABC"],
+            "observed_on": [datetime.datetime(2023, 6, 17, 16, 40)],
+            "location": [35.3299475067, -84.1795960441],
+            "place_guess": "Duke University",
+            "user": {"login": "bob"},
+            "species_guess": "Equus grevyi",
+        }
+        mock_get_observations.return_value = {"results": [item]}
+
+        obs, warnings = get_inaturalist_observations(user_id="user-1")
+
+        self.assertEqual(len(obs), 1)
+        first_obs = obs[0]
+        self.assertEqual(first_obs.keys(), set(expected_columns))
+        self.assertEqual(first_obs["Image_Label"], "p1")
+        self.assertEqual(first_obs["Image_Link"], "https://example.com/p1_medium.png")
+        self.assertEqual(first_obs["Species"], "Equus grevyi")
+        self.assertEqual(first_obs["Seconds"][0], 60000)
+        self.assertEqual(first_obs["Place"], "Duke University")
+        self.assertEqual(first_obs["Lat"], 35.3299475067)
+        self.assertEqual(first_obs["Long"], -84.1795960441)
+        self.assertEqual(warnings, [])
+
+    @patch("inaturalist.get_observations")
+    def test_get_inaturalist_observations_lat_lon_warning(self, mock_get_observations):
+        item = {
+            "photos": [{"url": "https://example.com/p1_square.png"}],
+            "p1": ["ABC"],
+            "observed_on": [datetime.datetime(2023, 6, 17, 16, 40)],
+            "place_guess": "Duke University",
+            "user": {"login": "bob"},
+            "species_guess": "Equus grevyi",
+        }
+
+        mock_get_observations.return_value = {"results": [item]}
+
+        obs, warnings = get_inaturalist_observations(user_id="user-1")
+        self.assertEqual(len(obs), 1)
+        self.assertEqual(warnings, ["missing_lat_long"])
+
+    def test_get_inaturalist_fieldnames(self):
+        expected_names = [
+            "Image_Label",
+            "Image_Link",
+            "Species",
+            "User",
+            "Date",
+            "Time",
+            "Seconds",
+            "Place",
+            "Lat",
+            "Long",
+        ]
+        self.assertEqual(get_inaturalist_fieldnames(), expected_names)
+
+    def test_create_csv_str(self):
+        observations = [
+            {
+                "Image_Label": "p1",
+                "Image_Link": "https://example.com/p1.png",
+            }
+        ]
+        result = create_csv_str(["Image_Label", "Image_Link"], observations)
+        self.assertEqual(
+            result.strip(), "Image_Label,Image_Link\np1,https://example.com/p1.png"
+        )

--- a/andromeda/tests/test_main.py
+++ b/andromeda/tests/test_main.py
@@ -5,66 +5,114 @@ from main import app
 
 
 class TestDataset(unittest.TestCase):
-    @patch('main.DatasetStore')
+    @patch("main.DatasetStore")
     def test_create_dataset(self, mock_dataset_store):
         mock_dataset_store.return_value.create_dataset.return_value = Mock(
-            id='9b4973f4-eba8-41b8-a3f9-acbadf49a2ca')
+            id="9b4973f4-eba8-41b8-a3f9-acbadf49a2ca"
+        )
 
         client = app.test_client()
-        result = client.post('/api/dataset/', data={
-            "file": (BytesIO(b"stuff"), "file.csv")
-        })
+        result = client.post(
+            "/api/dataset/", data={"file": (BytesIO(b"stuff"), "file.csv")}
+        )
         self.assertEqual(result.status_code, 200)
         self.assertEqual(result.json, {"id": "9b4973f4-eba8-41b8-a3f9-acbadf49a2ca"})
 
-    @patch('main.DatasetStore')
+    @patch("main.DatasetStore")
     def test_dimensional_reduction(self, mock_dataset_store):
         mock_dataset = Mock()
-        mock_weights = { "B1": 0.4 }
-        mock_coordinates = [{ "label":"p1", "x": 0.4, "y": 0.5 }]
-        mock_dataset.dimensional_reduction.return_value = (mock_weights, mock_coordinates)
+        mock_weights = {"B1": 0.4}
+        mock_coordinates = [{"label": "p1", "x": 0.4, "y": 0.5}]
+        mock_dataset.dimensional_reduction.return_value = (
+            mock_weights,
+            mock_coordinates,
+        )
         mock_dataset_store.return_value.get_dataset.return_value = mock_dataset
 
-        dataset_id = '9b4973f4-eba8-41b8-a3f9-acbadf49a2ca'
+        dataset_id = "9b4973f4-eba8-41b8-a3f9-acbadf49a2ca"
         client = app.test_client()
-        result = client.post(f'/api/dataset/{dataset_id}/dimensional-reduction',
-                             json={
-                                "weights": { "B1": 0.4 },
-                                "columnSettings": {
-                                    "label": "Image_Label",
-                                    "url": "Image_URL",
-                                    "selected": ["R1","B1","G1"],
-                                }
-                             })
+        result = client.post(
+            f"/api/dataset/{dataset_id}/dimensional-reduction",
+            json={
+                "weights": {"B1": 0.4},
+                "columnSettings": {
+                    "label": "Image_Label",
+                    "url": "Image_URL",
+                    "selected": ["R1", "B1", "G1"],
+                },
+            },
+        )
         self.assertEqual(result.status_code, 200)
-        self.assertEqual(result.json, {
-            "id": dataset_id,
-            "weights": mock_weights,
-            "images": mock_coordinates
-        })
+        self.assertEqual(
+            result.json,
+            {"id": dataset_id, "weights": mock_weights, "images": mock_coordinates},
+        )
 
-    @patch('main.DatasetStore')
+    @patch("main.DatasetStore")
     def test_inverse_dimensional_reduction(self, mock_dataset_store):
         mock_dataset = Mock()
-        mock_weights = { "B1": 0.4 }
-        mock_coordinates = [{ "label": "p1", "x": 0.4, "y": 0.5 }]
-        mock_dataset.inverse_dimensional_reduction.return_value = (mock_weights, mock_coordinates)
+        mock_weights = {"B1": 0.4}
+        mock_coordinates = [{"label": "p1", "x": 0.4, "y": 0.5}]
+        mock_dataset.inverse_dimensional_reduction.return_value = (
+            mock_weights,
+            mock_coordinates,
+        )
         mock_dataset_store.return_value.get_dataset.return_value = mock_dataset
 
-        dataset_id = '9b4973f4-eba8-41b8-a3f9-acbadf49a2ca'
+        dataset_id = "9b4973f4-eba8-41b8-a3f9-acbadf49a2ca"
         client = app.test_client()
-        result = client.post(f'/api/dataset/{dataset_id}/inverse-dimensional-reduction',
-                             json={
-                                "images": [{ "label": "p1", "x": 0.1, "y": 0.1 }],
-                                "columnSettings": {
-                                    "label": "Image_Label",
-                                    "url": "Image_URL",
-                                    "selected": ["R1","B1","G1"],
-                                }
-                             })
+        result = client.post(
+            f"/api/dataset/{dataset_id}/inverse-dimensional-reduction",
+            json={
+                "images": [{"label": "p1", "x": 0.1, "y": 0.1}],
+                "columnSettings": {
+                    "label": "Image_Label",
+                    "url": "Image_URL",
+                    "selected": ["R1", "B1", "G1"],
+                },
+            },
+        )
         self.assertEqual(result.status_code, 200)
-        self.assertEqual(result.json, {
-            "id": dataset_id,
-            "weights": mock_weights,
-            "images": mock_coordinates
-        })
+        self.assertEqual(
+            result.json,
+            {"id": dataset_id, "weights": mock_weights, "images": mock_coordinates},
+        )
+
+    @patch("main.get_inaturalist_observations")
+    def test_get_inaturalist(self, mock_get_inaturalist_observations):
+        observations = [{"Image_Label": "p1"}]
+        warnings = ["missing_lat_long"]
+        mock_get_inaturalist_observations.return_value = (observations, warnings)
+        client = app.test_client()
+        result = client.get(f"/api/inaturalist/bob")
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(
+            result.json,
+            {
+                "data": [{"Image_Label": "p1"}],
+                "user_id": "bob",
+                "warnings": ["missing_lat_long"],
+            },
+        )
+
+    @patch("main.get_inaturalist_observations")
+    def test_get_inaturalist_csv(self, mock_get_inaturalist_observations):
+        observations = [{"Image_Label": "p1"}]
+        warnings = ["missing_lat_long"]
+        mock_get_inaturalist_observations.return_value = (observations, warnings)
+        client = app.test_client()
+        result = client.get(f"/api/inaturalist/bob?format=csv")
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(
+            result.text.strip(),
+            "Image_Label,Image_Link,Species,User,Date,Time,Seconds,Place,Lat,Long\n"
+            + "p1,,,,,,,,,",
+        )
+
+    @patch("main.get_inaturalist_observations")
+    def test_get_inaturalist_xml(self, mock_get_inaturalist_observations):
+        mock_get_inaturalist_observations.return_value = ([], [])
+        client = app.test_client()
+        result = client.get(f"/api/inaturalist/bob?format=xml")
+        self.assertEqual(result.status_code, 400)
+        self.assertEqual(result.json.get("description"), "Unsupported format parameter value xml")


### PR DESCRIPTION
Adds logic to fetch iNaturalist observations as either JSON or CSV based on a [puddin-l/Quest_Project_2022 notebook](https://github.com/puddin-l/Quest_Project_2022/blob/main/Quest_Project_2022.ipynb) via  in commit https://github.com/Imageomics/Andromeda/commit/2822f138a7fe354de485a2a7e15b9a27611880b5. Subsequent commits add tests and API endpoints that expose the iNaturalist observation fetching code.