### PR TITLE
Add options to merge satellite data

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Part of the deployment builds the docker containers used by the website, so it m
 To stop the app run `docker-compose down`.
 
 Settings for the app can be changed in `.env`.
+Options for `.env`:
+- BACKEND_WORKERS - number of [workers used by gunicorn](https://docs.gunicorn.org/en/latest/run.html#commonly-used-arguments)
+- ANDROMEDA_RGB_SATELLITE_URL - URL pointing to a CSV file for joining RGB data
+- ANDROMEDA_LANDCOVER_URL - Optional URL pointing to a CSV file for joining Landcover data
+
 
 ### Certbot Setup on AWS
 Certificates can be installed to the EC2 VM using Certbot with Nginx on pip following [EFF instructions](https://certbot.eff.org/instructions?ws=nginx&os=pip).

--- a/andromeda-ui/backend/observations.ts
+++ b/andromeda-ui/backend/observations.ts
@@ -1,7 +1,7 @@
 import { fetch_json, apiURL } from "./util";
 
-export async function fetchObservations(iNatUser: string) {
-    const url = makeObservationURL(iNatUser, "json");
+export async function fetchObservations(iNatUser: string, addSatCSV: boolean, addLandCover: boolean) {
+    const url = makeObservationURL(iNatUser, addSatCSV, addLandCover, "json");
     return await fetch_json(url, {
       method: "GET",
       headers: {
@@ -10,10 +10,12 @@ export async function fetchObservations(iNatUser: string) {
     });
 }
 
-export function makeObservationURL(iNatUser: string, format: "json" | "csv") {
+export function makeObservationURL(iNatUser: string, addSatCSV: boolean, addLandCover: boolean, format: "json" | "csv") {
   let base_url = "/inaturalist/" + iNatUser;
   if (format) {
     base_url += "?format=" + format;
   }
+  base_url += "&add_sat_csv_data=" + addSatCSV;
+  base_url += "&add_land_api_data=" + addLandCover;
   return apiURL(base_url);
 }

--- a/andromeda-ui/backend/observations.ts
+++ b/andromeda-ui/backend/observations.ts
@@ -1,7 +1,7 @@
 import { fetch_json, apiURL } from "./util";
 
-export async function fetchObservations(iNatUser: string, addSatCSV: boolean, addLandCover: boolean) {
-    const url = makeObservationURL(iNatUser, addSatCSV, addLandCover, "json");
+export async function fetchObservations(iNatUser: string, addSatRGB: boolean, addLandCover: boolean) {
+    const url = makeObservationURL(iNatUser, addSatRGB, addLandCover, "json");
     return await fetch_json(url, {
       method: "GET",
       headers: {
@@ -10,12 +10,12 @@ export async function fetchObservations(iNatUser: string, addSatCSV: boolean, ad
     });
 }
 
-export function makeObservationURL(iNatUser: string, addSatCSV: boolean, addLandCover: boolean, format: "json" | "csv") {
+export function makeObservationURL(iNatUser: string, addSatRGB: boolean, addLandCover: boolean, format: "json" | "csv") {
   let base_url = "/inaturalist/" + iNatUser;
   if (format) {
     base_url += "?format=" + format;
   }
-  base_url += "&add_sat_csv_data=" + addSatCSV;
-  base_url += "&add_land_api_data=" + addLandCover;
+  base_url += "&add_sat_rgb_data=" + addSatRGB;
+  base_url += "&add_landcover_data=" + addLandCover;
   return apiURL(base_url);
 }

--- a/andromeda-ui/components/FetchDataForm.tsx
+++ b/andromeda-ui/components/FetchDataForm.tsx
@@ -1,21 +1,21 @@
 import ColoredButton from "../components/ColoredButton";
-import SimpleSelect from "./SimpleSelect";
 
 interface FetchDataFormProps {
     iNatUser: string | undefined;
     setINatUser: (user: string) => void;
     disableFetchButton: boolean;
     onClickFetch: () => void;
-    addSatCSVData: boolean;
-    setAddSatCSVData: (add: boolean) => void;
+    addSatRGBData: boolean;
+    setAddSatRGBData: (add: boolean) => void;
     addLandCover: boolean;
     setAddLandCover: (add: boolean) => void;
 }
 
 export default function FetchDataForm(props: FetchDataFormProps) {
-    const {iNatUser, setINatUser, disableFetchButton, onClickFetch, addSatCSVData, setAddSatCSVData, addLandCover, setAddLandCover} = props;
+    const {iNatUser, setINatUser, disableFetchButton, onClickFetch, 
+        addSatRGBData, setAddSatRGBData, addLandCover, setAddLandCover} = props;
     function onChangeCSV(event: any){
-        setAddSatCSVData(event.target.checked)
+        setAddSatRGBData(event.target.checked)
     }
     function onChangeLand(event: any){
         setAddLandCover(event.target.checked)
@@ -30,10 +30,10 @@ export default function FetchDataForm(props: FetchDataFormProps) {
                 value={iNatUser}
                 onChange={(e: any) => setINatUser(e.target.value)} />
         
-            <label className="mr-2 text-md font-medium" htmlFor="AddSatCSV">RGB Satellite Data</label>
-            <input className="mr-4 accent-cyan-600" type="checkbox" id="AddSatCSV" checked={addSatCSVData} onChange={onChangeCSV}></input>
+            <label className="mr-2 text-md font-medium" htmlFor="AddSatCSV">RGB Satellite Data:</label>
+            <input className="mr-4 accent-cyan-600" type="checkbox" id="AddSatCSV" checked={addSatRGBData} onChange={onChangeCSV}></input>
     
-            <label className="mr-2 text-md font-medium" htmlFor="AddLandCover">Landcover Data</label>
+            <label className="mr-2 text-md font-medium" htmlFor="AddLandCover">Landcover Satellite Data:</label>
             <input className="accent-cyan-600" type="checkbox" id="AddLandCover" checked={addLandCover} onChange={onChangeLand}></input>
         </div>
         <div className="my-2">

--- a/andromeda-ui/components/FetchDataForm.tsx
+++ b/andromeda-ui/components/FetchDataForm.tsx
@@ -1,23 +1,40 @@
 import ColoredButton from "../components/ColoredButton";
+import SimpleSelect from "./SimpleSelect";
 
 interface FetchDataFormProps {
     iNatUser: string | undefined;
     setINatUser: (user: string) => void;
     disableFetchButton: boolean;
     onClickFetch: () => void;
+    addSatCSVData: boolean;
+    setAddSatCSVData: (add: boolean) => void;
+    addLandCover: boolean;
+    setAddLandCover: (add: boolean) => void;
 }
 
 export default function FetchDataForm(props: FetchDataFormProps) {
-    const {iNatUser, setINatUser, disableFetchButton, onClickFetch} = props;
+    const {iNatUser, setINatUser, disableFetchButton, onClickFetch, addSatCSVData, setAddSatCSVData, addLandCover, setAddLandCover} = props;
+    function onChangeCSV(event: any){
+        setAddSatCSVData(event.target.checked)
+    }
+    function onChangeLand(event: any){
+        setAddLandCover(event.target.checked)
+    }
     return <>
         <p className="max-w-2xl text-sm my-2">
             Find iNaturalist observations to create a CSV file that can be visualized in Andromeda.
         </p>
         <div className="py-1">
             <label className="mr-2 text-md font-medium" htmlFor="iNatUser">iNaturalist Username:</label>
-            <input className="border rounded p-1" type="text" id="iNatUser" name="iNatUser" required
+            <input className="mr-4 border rounded p-1" type="text" id="iNatUser" name="iNatUser" required
                 value={iNatUser}
                 onChange={(e: any) => setINatUser(e.target.value)} />
+        
+            <label className="mr-2 text-md font-medium" htmlFor="AddSatCSV">RGB Satellite Data</label>
+            <input className="mr-4 accent-cyan-600" type="checkbox" id="AddSatCSV" checked={addSatCSVData} onChange={onChangeCSV}></input>
+    
+            <label className="mr-2 text-md font-medium" htmlFor="AddLandCover">Landcover Data</label>
+            <input className="accent-cyan-600" type="checkbox" id="AddLandCover" checked={addLandCover} onChange={onChangeLand}></input>
         </div>
         <div className="my-2">
             <ColoredButton disabled={disableFetchButton} label="Fetch Observations" color="blue" onClick={onClickFetch} />

--- a/andromeda-ui/pages/fetch-data/index.tsx
+++ b/andromeda-ui/pages/fetch-data/index.tsx
@@ -15,20 +15,21 @@ const FETCH_WARNINGS: any = {
     Missing latitude and longitude for some iNaturalist observations.
     Please fix these observations at iNaturalist.org.`,
     multiple_sat_matches: `Multiple satellite entries found for a single location.`,
-    no_sat_matches: `No matching satellite data found.`
+    no_sat_matches: `No matching satellite data found.`,
+    landcover_not_setup: `Landcover data is not currently supported.`
 }
 
 function makeMessages(warnings: string[]): string {
     if (warnings) {
         const messages = warnings.map((x: string) => FETCH_WARNINGS[x] || x);
-        return messages.join(", ");
+        return messages.join(" ");
     }
     return "";
 }
 
 export default function GeneratePage() {
     const [iNatUser, setINatUser] = useState<string>("");
-    const [addSatCSVData, setAddSatCSVData] = useState<boolean>(false);
+    const [addSatRGBData, setAddSatRGBData] = useState<boolean>(false);
     const [addLandCover, setAddLandCover] = useState<boolean>(false);
     const [warning, setWarning] = useState<string>("");
     const [fetching, setFetching] = useState<boolean>(false);
@@ -40,7 +41,7 @@ export default function GeneratePage() {
             setWarning("");
             setFetching(true);
             try {
-                const result = await fetchObservations(iNatUser, addSatCSVData, addLandCover);
+                const result = await fetchObservations(iNatUser, addSatRGBData, addLandCover);
                 setObservations(result.data);
                 if (result.warnings.length) {
                     setWarning(makeMessages(result.warnings));
@@ -75,7 +76,7 @@ export default function GeneratePage() {
         warningNotice = <WarningNotice message={warning} />;
     }
     if (showObservations) {
-        const csvURL = makeObservationURL(iNatUser, addSatCSVData, addLandCover, "csv");
+        const csvURL = makeObservationURL(iNatUser, addSatRGBData, addLandCover, "csv");
         content = <div>
             <ObservationTable
                 iNatUser={iNatUser}
@@ -92,8 +93,8 @@ export default function GeneratePage() {
             <FetchDataForm
                 iNatUser={iNatUser}
                 setINatUser={setINatUser}
-                addSatCSVData={addSatCSVData}
-                setAddSatCSVData={setAddSatCSVData}
+                addSatRGBData={addSatRGBData}
+                setAddSatRGBData={setAddSatRGBData}
                 addLandCover={addLandCover}
                 setAddLandCover={setAddLandCover}
                 disableFetchButton={fetching}

--- a/andromeda-ui/pages/fetch-data/index.tsx
+++ b/andromeda-ui/pages/fetch-data/index.tsx
@@ -13,7 +13,9 @@ const SHOW_OBS_MAX = 6;
 const FETCH_WARNINGS: any = {
     missing_lat_long: `Warning:
     Missing latitude and longitude for some iNaturalist observations.
-    Please fix these observations at iNaturalist.org.`
+    Please fix these observations at iNaturalist.org.`,
+    multiple_sat_matches: `Multiple satellite entries found for a single location.`,
+    no_sat_matches: `No matching satellite data found.`
 }
 
 function makeMessages(warnings: string[]): string {

--- a/andromeda-ui/pages/fetch-data/index.tsx
+++ b/andromeda-ui/pages/fetch-data/index.tsx
@@ -28,6 +28,8 @@ function makeMessages(warnings: string[]): string {
 
 export default function GeneratePage() {
     const [iNatUser, setINatUser] = useState<string>("");
+    const [addSatCSVData, setAddSatCSVData] = useState<boolean>(false);
+    const [addLandCover, setAddLandCover] = useState<boolean>(false);
     const [warning, setWarning] = useState<string>("");
     const [fetching, setFetching] = useState<boolean>(false);
     const [showObservations, setShowObservations] = useState<boolean>(false);
@@ -38,7 +40,7 @@ export default function GeneratePage() {
             setWarning("");
             setFetching(true);
             try {
-                const result = await fetchObservations(iNatUser);
+                const result = await fetchObservations(iNatUser, addSatCSVData, addLandCover);
                 setObservations(result.data);
                 if (result.warnings.length) {
                     setWarning(makeMessages(result.warnings));
@@ -73,7 +75,7 @@ export default function GeneratePage() {
         warningNotice = <WarningNotice message={warning} />;
     }
     if (showObservations) {
-        const csvURL = makeObservationURL(iNatUser, "csv");
+        const csvURL = makeObservationURL(iNatUser, addSatCSVData, addLandCover, "csv");
         content = <div>
             <ObservationTable
                 iNatUser={iNatUser}
@@ -90,6 +92,10 @@ export default function GeneratePage() {
             <FetchDataForm
                 iNatUser={iNatUser}
                 setINatUser={setINatUser}
+                addSatCSVData={addSatCSVData}
+                setAddSatCSVData={setAddSatCSVData}
+                addLandCover={addLandCover}
+                setAddLandCover={setAddLandCover}
                 disableFetchButton={fetching}
                 onClickFetch={onClickFetch}/>
             {warningNotice}

--- a/andromeda-ui/tests/backend/observations.test.ts
+++ b/andromeda-ui/tests/backend/observations.test.ts
@@ -8,13 +8,23 @@ jest.mock('next/config', () => () => ({
 }))
 
 test("makeObservationURL can create a json url", () => {
-    const expected = "https://example.com/api/inaturalist/bob?format=json";
-    expect(makeObservationURL("bob", "json")).toStrictEqual(expected);
+    const expected = "https://example.com/api/inaturalist/bob?format=json&add_sat_rgb_data=false&add_landcover_data=false";
+    expect(makeObservationURL("bob", false, false, "json")).toStrictEqual(expected);
 });
 
 test("makeObservationURL creates a CSV URL", () => {
-    const expected = "https://example.com/api/inaturalist/bob?format=csv";
-    expect(makeObservationURL("bob", "csv")).toStrictEqual(expected);
+    const expected = "https://example.com/api/inaturalist/bob?format=csv&add_sat_rgb_data=false&add_landcover_data=false";
+    expect(makeObservationURL("bob",false, false, "csv")).toStrictEqual(expected);
+});
+
+test("makeObservationURL can add RGB data param", () => {
+    const expected = "https://example.com/api/inaturalist/bob?format=json&add_sat_rgb_data=true&add_landcover_data=false";
+    expect(makeObservationURL("bob", true, false, "json")).toStrictEqual(expected);
+});
+
+test("makeObservationURL can add landcover data param", () => {
+    const expected = "https://example.com/api/inaturalist/bob?format=json&add_sat_rgb_data=false&add_landcover_data=true";
+    expect(makeObservationURL("bob", false, true, "json")).toStrictEqual(expected);
 });
 
 test("fetchObservations returns JSON result of observations", async () => {
@@ -23,8 +33,8 @@ test("fetchObservations returns JSON result of observations", async () => {
         "data": [{"label": "p1"}],
         "warnings": ["some_warning"]        
     }
-    fetchMock.get('https://example.com/api/inaturalist/bob?format=json', payload);
-    const results = await fetchObservations("bob");
+    fetchMock.get('https://example.com/api/inaturalist/bob?format=json&add_sat_rgb_data=false&add_landcover_data=false', payload);
+    const results = await fetchObservations("bob", false, false);
     expect(results).toStrictEqual(payload);
     fetchMock.restore();
 });

--- a/andromeda/inaturalist.py
+++ b/andromeda/inaturalist.py
@@ -2,7 +2,7 @@ import io
 import csv
 import pandas as pd
 from pyinaturalist import get_observations
-from satellitedata import add_satellite_csv_data
+from satellitedata import add_satellite_rgb_data, add_satellite_landcover_data
 
 LABEL_FIELD = "Image_Label"
 URL_FIELD = "Image_Link"
@@ -26,31 +26,30 @@ CSV_FIELDS = [
     LAT_FIELD,
     LON_FIELD,
 ]
-SATELLITE_DATA_URL = "https://raw.githubusercontent.com/Imageomics/Andromeda/main/datasets/satelliteData/satImgs3Cluster_1000-ft.csv"
 
 
 class Observations(object):
     def __init__(self, fieldnames):
         self.fieldnames = fieldnames
         self.data = []
-        self.warnings = []
+        self.warnings = set()
 
     def add(self, row):
         self.data.append(row)
 
     def add_warning(self, warning):
-        self.warnings.append(warning)
+        self.warnings.add(warning)
 
     def add_fieldnames(self, new_fieldnames):
         self.fieldnames.extend(new_fieldnames)
 
 
-def get_inaturalist_observations(user_id, add_sat_csv_data, add_sat_api_data):
+def get_inaturalist_observations(user_id, add_sat_rgb_data, add_landcover_data):
     idx = 0
     missing_lat_long = False
     observations = Observations(fieldnames=CSV_FIELDS[:])
-    obeservations_response = get_observations(user_id=user_id, page="all")
-    for obs in obeservations_response["results"]:
+    observations_response = get_observations(user_id=user_id, page="all")
+    for obs in observations_response["results"]:
         idx += 1
         label = f"p{idx}"
         df = pd.DataFrame.from_dict(obs, orient="index")
@@ -91,11 +90,11 @@ def get_inaturalist_observations(user_id, add_sat_csv_data, add_sat_api_data):
     if missing_lat_long:
         observations.add_warning("missing_lat_long")
 
-    if add_sat_csv_data:
-        add_satellite_csv_data(observations, LAT_FIELD, LON_FIELD, SATELLITE_DATA_URL)
+    if add_sat_rgb_data:
+        add_satellite_rgb_data(observations, LAT_FIELD, LON_FIELD)
 
-    if add_sat_api_data:
-        add_sat_api_data(observations, LAT_FIELD, LON_FIELD)
+    if add_landcover_data:
+        add_satellite_landcover_data(observations, LAT_FIELD, LON_FIELD)
 
     return observations
 

--- a/andromeda/main.py
+++ b/andromeda/main.py
@@ -4,7 +4,7 @@ from flask import Flask, Response, request, jsonify, abort, json
 from werkzeug.exceptions import HTTPException
 from flask_cors import CORS
 from dataset import DatasetStore
-from inaturalist import get_inaturalist_observations, get_inaturalist_fieldnames, create_csv_str
+from inaturalist import get_inaturalist_observations, create_csv_str
 
 UPLOAD_FOLDER = os.environ.get('ANDROMEDA_UPLOAD_DIR', '/tmp/andromeda_uploads')
 app = Flask(__name__)
@@ -101,18 +101,20 @@ def inverse_dimensional_reduction(dataset_id):
 @app.route('/api/inaturalist/<user_id>', methods=['GET'])
 def get_inaturalist(user_id):
     format = request.args.get("format", "json").lower()
-    fieldnames = get_inaturalist_fieldnames()
-    obs, warnings = get_inaturalist_observations(user_id=user_id)
+    # TODO read query params for add_sat_csv_data and add_sat_api_data
+    observations = get_inaturalist_observations(user_id=user_id,
+                                                 add_sat_csv_data=True,
+                                                 add_sat_api_data=True)
     if format == "json":    
         return jsonify({
             "user_id": user_id,
-            "data": obs,
-            "warnings": warnings
+            "data": observations.data,
+            "warnings": observations.warnings
         })
     elif format == "csv":
         return csv_reponse_for_observations(
-            fieldnames=fieldnames,
-            observations=obs,
+            fieldnames=observations.fieldnames,
+            observations=observations.data,
             user_id=user_id
         )
     else:

--- a/andromeda/requirements.txt
+++ b/andromeda/requirements.txt
@@ -3,3 +3,4 @@ scikit-learn==1.2.2
 Flask==2.3.2
 Flask-Cors==3.0.10
 pyinaturalist==0.18.0
+geopandas==0.13.2

--- a/andromeda/satellitedata.py
+++ b/andromeda/satellitedata.py
@@ -1,0 +1,49 @@
+import pandas as pd
+import shapely
+import geopandas
+
+SAT_LABEL = "sat_label"
+# 4 columns representing bounds of the satellite data
+LAT_NW = "sat_Lat-NW"
+LON_NW = "sat_Lon-NW"
+LAT_SE = "sat_Lat-SE"
+LON_SE = "sat_Lon-SE"
+
+
+def make_shapely_box(row):
+    return shapely.box(row[LAT_SE], row[LON_NW], row[LAT_NW], row[LON_SE])
+
+
+def read_satellite_data(url):
+    sat_df = pd.read_csv(url)
+    sat_geo_series = geopandas.GeoSeries(sat_df.apply(make_shapely_box, axis=1))
+    return sat_df, sat_geo_series
+
+
+def find_satellite_records(sat_df, sat_geo_series, lat, long):
+    point = shapely.Point(lat, long)
+    matches_ary = sat_geo_series.contains(point)
+    return sat_df[matches_ary].to_dict(orient="records")
+
+
+def add_satellite_csv_data(observations, lat_fieldname, long_fieldname, satellite_csv_url):
+    sat_df, sat_geo_series = read_satellite_data(satellite_csv_url)
+    observations.add_fieldnames(list(sat_df.columns))
+    has_a_match = False
+    for obs in observations.data:
+        lat = obs[lat_fieldname]
+        long = obs[long_fieldname]
+        if lat and long:
+            matches = find_satellite_records(sat_df, sat_geo_series, lat, long)
+            if matches:
+                if len(matches) > 1:
+                    observations.add_warning("multiple_sat_matches")
+                obs.update(matches[0])
+                has_a_match = True
+    if not has_a_match:
+        observations.add_warning("no_sat_matches")
+
+
+def add_satellite_api_data(observations, lat_fieldname, long_fieldname):
+    # TODO add in code to fetch data from a satellite API and add to the observations
+    pass

--- a/andromeda/satellitedata.py
+++ b/andromeda/satellitedata.py
@@ -1,13 +1,18 @@
+import os
 import pandas as pd
 import shapely
 import geopandas
 
-SAT_LABEL = "sat_label"
 # 4 columns representing bounds of the satellite data
 LAT_NW = "sat_Lat-NW"
 LON_NW = "sat_Lon-NW"
 LAT_SE = "sat_Lat-SE"
 LON_SE = "sat_Lon-SE"
+RGB_SATELLITE_URL = os.environ.get(
+    "ANDROMEDA_RGB_SATELLITE_URL",
+    "https://raw.githubusercontent.com/Imageomics/Andromeda/main/datasets/satelliteData/satRgbFinal4.csv"
+)
+LANDCOVER_SATELLITE_URL = os.environ.get("ANDROMEDA_LANDCOVER_URL")
 
 
 def make_shapely_box(row):
@@ -26,8 +31,8 @@ def find_satellite_records(sat_df, sat_geo_series, lat, long):
     return sat_df[matches_ary].to_dict(orient="records")
 
 
-def add_satellite_csv_data(observations, lat_fieldname, long_fieldname, satellite_csv_url):
-    sat_df, sat_geo_series = read_satellite_data(satellite_csv_url)
+def merge_lat_long_csv_url(observations, lat_fieldname, long_fieldname, url):
+    sat_df, sat_geo_series = read_satellite_data(url)
     observations.add_fieldnames(list(sat_df.columns))
     has_a_match = False
     for obs in observations.data:
@@ -44,6 +49,12 @@ def add_satellite_csv_data(observations, lat_fieldname, long_fieldname, satellit
         observations.add_warning("no_sat_matches")
 
 
-def add_satellite_api_data(observations, lat_fieldname, long_fieldname):
-    # TODO add in code to fetch data from a satellite API and add to the observations
-    pass
+def add_satellite_rgb_data(observations, lat_fieldname, long_fieldname):
+    merge_lat_long_csv_url(observations, lat_fieldname, long_fieldname, RGB_SATELLITE_URL)
+
+
+def add_satellite_landcover_data(observations, lat_fieldname, long_fieldname):
+    if LANDCOVER_SATELLITE_URL:
+        merge_lat_long_csv_url(observations, lat_fieldname, long_fieldname, LANDCOVER_SATELLITE_URL)
+    else:
+        observations.add_warning("landcover_not_setup")

--- a/andromeda/tests/test_satellitedata.py
+++ b/andromeda/tests/test_satellitedata.py
@@ -1,0 +1,120 @@
+import pandas as pd
+import unittest
+from unittest.mock import Mock, patch
+
+from satellitedata import (
+    add_satellite_rgb_data,
+    add_satellite_landcover_data,
+    LAT_NW, LAT_SE, LON_NW, LON_SE
+)
+
+
+def sample_rgb_dataframe():
+    columns = [LAT_NW, LON_NW, LAT_SE, LON_SE, "Number"]
+    data = [
+        (40.332624,	-74.749758,	40.313732,	-74.707701, 111),
+        (40.365821,	-74.76289,	40.345643,	-74.720636, 222),
+        (32, 32, 28, 28, 333),
+        (31, 31, 27, 27, 444),
+    ]
+    return pd.DataFrame.from_records(data, columns=columns)
+
+
+def sample_observation_data():
+    return [
+        {
+            "id": "p1",
+            "Lat": 40.33,
+            "Long": -74.73
+        }, {
+            "id": "p2",
+            "Lat": 40.35,
+            "Long": -74.75
+        }, {
+            "id": "p3",
+            "Lat": 40.32,
+            "Long": -74.75
+        }
+    ]
+
+
+class TestSatelliteData(unittest.TestCase):
+    @patch("satellitedata.pd")
+    @patch("satellitedata.RGB_SATELLITE_URL")
+    def test_add_satellite_rgb_data(self, mock_rgb_url, mock_pd):
+        sat_df = sample_rgb_dataframe()
+        mock_pd.read_csv.return_value = sat_df
+        observations = Mock(data=sample_observation_data())
+        add_satellite_rgb_data(
+            observations=observations,
+            lat_fieldname='Lat',
+            long_fieldname='Long')
+        self.assertEqual(len(observations.data), 3)
+        self.assertEqual(observations.data[0]["id"], "p1")
+        self.assertEqual(observations.data[0]["Number"], 111)
+        self.assertEqual(observations.data[1]["id"], "p2")
+        self.assertEqual(observations.data[1]["Number"], 222)
+        self.assertEqual(observations.data[2]["id"], "p3")
+        self.assertEqual(observations.data[2].get("Number"), None)
+        self.assertEqual(observations.add_warning.called, False)
+        mock_pd.read_csv.assert_called_with(mock_rgb_url)
+
+    @patch("satellitedata.pd")
+    def test_add_satellite_rgb_data_no_match(self, mock_pd):
+        sat_df = sample_rgb_dataframe()
+        mock_pd.read_csv.return_value = sat_df
+        unmatched_lat_long_data = [{
+            "id": "p3",
+            "Lat": 40.32,
+            "Long": -74.75
+        }]
+        observations = Mock(data=unmatched_lat_long_data)
+        add_satellite_rgb_data(
+            observations=observations,
+            lat_fieldname='Lat',
+            long_fieldname='Long')
+        self.assertEqual(len(observations.data), 1)
+        self.assertEqual(observations.data[0]["id"], "p3")
+        self.assertEqual(observations.data[0].get("Number"), None)
+        self.assertEqual(observations.add_warning.called, True)
+        observations.add_warning.assert_called_with('no_sat_matches')
+
+    @patch("satellitedata.pd")
+    def test_add_satellite_rgb_data_duplicates(self, mock_pd):
+        sat_df = sample_rgb_dataframe()
+        mock_pd.read_csv.return_value = sat_df
+        unmatched_lat_long_data = [{
+            "id": "p3",
+            "Lat": 30,
+            "Long": 30
+        }]
+        observations = Mock(data=unmatched_lat_long_data)
+        add_satellite_rgb_data(
+            observations=observations,
+            lat_fieldname='Lat',
+            long_fieldname='Long')
+        self.assertEqual(len(observations.data), 1)
+        self.assertEqual(observations.data[0]["id"], "p3")
+        #self.assertEqual(observations.data[0].get("Number"), None)
+        self.assertEqual(observations.add_warning.called, True)
+        observations.add_warning.assert_called_with('multiple_sat_matches')
+
+    @patch("satellitedata.pd")
+    @patch("satellitedata.LANDCOVER_SATELLITE_URL")
+    def test_add_satellite_landcover_data(self, mock_lc_url, mock_pd):
+        sat_df = sample_rgb_dataframe()
+        mock_pd.read_csv.return_value = sat_df
+        observations = Mock(data=sample_observation_data())
+        add_satellite_landcover_data(
+            observations=observations,
+            lat_fieldname='Lat',
+            long_fieldname='Long')
+        self.assertEqual(len(observations.data), 3)
+        self.assertEqual(observations.data[0]["id"], "p1")
+        self.assertEqual(observations.data[0]["Number"], 111)
+        self.assertEqual(observations.data[1]["id"], "p2")
+        self.assertEqual(observations.data[1]["Number"], 222)
+        self.assertEqual(observations.data[2]["id"], "p3")
+        self.assertEqual(observations.data[2].get("Number"), None)
+        self.assertEqual(observations.add_warning.called, False)
+        mock_pd.read_csv.assert_called_with(mock_lc_url)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - "5000"
     environment:
       - BACKEND_WORKERS=${BACKEND_WORKERS}
+      - ANDROMEDA_RGB_SATELLITE_URL=${ANDROMEDA_RGB_SATELLITE_URL}
+      - ANDROMEDA_LANDCOVER_URL=${ANDROMEDA_LANDCOVER_URL}
 
   nginx:
     container_name: frontend

--- a/example.env
+++ b/example.env
@@ -1,1 +1,3 @@
 BACKEND_WORKERS=4
+ANDROMEDA_RGB_SATELLITE_URL=https://raw.githubusercontent.com/Imageomics/Andromeda/main/datasets/satelliteData/satRgbFinal4.csv
+ANDROMEDA_LANDCOVER_URL=


### PR DESCRIPTION
Adds two checkboxes to allow users to join RGB and Land coverage satellite data into the iNaturalist observations downloaded. 