### PR TITLE
Add support for overlapping sat regions 

### DIFF
--- a/andromeda-ui/components/ObservationTable.tsx
+++ b/andromeda-ui/components/ObservationTable.tsx
@@ -7,18 +7,39 @@ interface ObservationTableProps {
 }
 
 const TH_CLASSNAME = "p-2 border text-slate-500 font-semi-bold text-sm"
-const TD_CLASSNAME = "p-1 border text-slate-500 text-sm"
+const TD_CLASSNAME = "p-1 border text-slate-500 text-sm whitespace-nowrap text-ellipsis"
+const KNOWN_COLUMNS = new Set([
+    "Image_Label",
+    "Image_Link",
+    "Date",
+    "Time",
+    "Lat",
+    "Long",
+    "Species",
+    "Place",
+    "Seconds",
+    "User"
+]);
 
 export default function ObservationTable(props: ObservationTableProps) {
     const { observations, maxObs, iNatUser } = props;
     const showing = Math.min(observations.length, maxObs);
+    let extraColumns: string[] = [];
+    if (observations.length > 0) {
+        extraColumns = Object.keys(observations[0]).filter((x) => !KNOWN_COLUMNS.has(x))
+    }
     const rows = observations.slice(0, maxObs).map((x) => {
+        const extraColumnValues = extraColumns.map(colname => {
+            return <td key={colname + "_" + x.Image_Label} className={TD_CLASSNAME}>
+                {x[colname]}
+            </td>;
+        })
         return <tr key={x.Image_Label}>
-            <td className={TD_CLASSNAME}>{x.Image_Label}</td>
+            <td className={TD_CLASSNAME + " sticky left-0 bg-white"}>{x.Image_Label}</td>
             <td className={TD_CLASSNAME}>
                 <Image
-                    width="64"
-                    height="64"
+                    width={50}
+                    height={50}
                     src={x.Image_Link}
                     alt={x.Image_Label}
                     title={x.Image_Link} />
@@ -47,31 +68,38 @@ export default function ObservationTable(props: ObservationTableProps) {
             <td className={TD_CLASSNAME}>
                 {x.User}
             </td>
+            {extraColumnValues}
         </tr>
     });
+    const extraColumnHeaders = extraColumns.map(colname => {
+        return <th key={colname} className={TH_CLASSNAME}>{colname}</th>;
+    })
     return <>
         <div className="my-1">
             <span className="text-lg flex-auto">Observations by {iNatUser}</span>
         </div>
-        <table className="border-collapse border">
-            <thead className="bg-slate-50 border-slate-400">
-                <tr>
-                    <th className={TH_CLASSNAME}>Image_Label</th>
-                    <th className={TH_CLASSNAME}>Image_Link</th>
-                    <th className={TH_CLASSNAME}>Date</th>
-                    <th className={TH_CLASSNAME}>Time</th>
-                    <th className={TH_CLASSNAME}>Lat</th>
-                    <th className={TH_CLASSNAME}>Long</th>
-                    <th className={TH_CLASSNAME}>Species</th>
-                    <th className={TH_CLASSNAME}>Place</th>
-                    <th className={TH_CLASSNAME}>Seconds</th>
-                    <th className={TH_CLASSNAME}>User</th>
-                </tr>
-            </thead>
-            <tbody>
-                {rows}
-            </tbody>
-        </table>
+        <div className="overflow-auto">
+            <table className="border-collapse border table-auto">
+                <thead className="bg-slate-50 border-slate-400">
+                    <tr>
+                        <th className={TH_CLASSNAME+ " sticky left-0 bg-slate-50"}>Image_Label</th>
+                        <th className={TH_CLASSNAME}>Image_Link</th>
+                        <th className={TH_CLASSNAME}>Date</th>
+                        <th className={TH_CLASSNAME}>Time</th>
+                        <th className={TH_CLASSNAME}>Lat</th>
+                        <th className={TH_CLASSNAME}>Long</th>
+                        <th className={TH_CLASSNAME}>Species</th>
+                        <th className={TH_CLASSNAME}>Place</th>
+                        <th className={TH_CLASSNAME}>Seconds</th>
+                        <th className={TH_CLASSNAME}>User</th>
+                        {extraColumnHeaders}
+                    </tr>
+                </thead>
+                <tbody>
+                    {rows}
+                </tbody>
+            </table>
+        </div>
         <span className="text-sm">
             Showing {showing} rows ({observations.length} in total)
         </span>

--- a/andromeda/satellitedata.py
+++ b/andromeda/satellitedata.py
@@ -28,7 +28,18 @@ def read_satellite_data(url):
 def find_satellite_records(sat_df, sat_geo_series, lat, long):
     point = shapely.Point(lat, long)
     matches_ary = sat_geo_series.contains(point)
-    return sat_df[matches_ary].to_dict(orient="records")
+    matches = sat_df[matches_ary]
+    # if the point exists in multiple regions find the closest to the centroid
+    if len(matches.index) > 1:
+        # calculate the distance between the point and the regions
+        distances = sat_geo_series.centroid.distance(point)
+        # find the minimum distance
+        min_distance = min(distances)
+        # find the closest points
+        closest = distances == min_distance
+        # those are our matches
+        matches = sat_df[closest]
+    return matches.to_dict(orient="records")
 
 
 def merge_lat_long_csv_url(observations, lat_fieldname, long_fieldname, url):

--- a/andromeda/tests/test_satellitedata.py
+++ b/andromeda/tests/test_satellitedata.py
@@ -12,10 +12,10 @@ from satellitedata import (
 def sample_rgb_dataframe():
     columns = [LAT_NW, LON_NW, LAT_SE, LON_SE, "Number"]
     data = [
-        (40.332624,	-74.749758,	40.313732,	-74.707701, 111),
+        (40.332624,	-74.749758,	40.313732,	-74.707701, 111,),
         (40.365821,	-74.76289,	40.345643,	-74.720636, 222),
-        (32, 32, 28, 28, 333),
-        (31, 31, 27, 27, 444),
+        (31, 31, 27, 27, 333),
+        (32, 32, 28, 28, 444),
     ]
     return pd.DataFrame.from_records(data, columns=columns)
 
@@ -95,9 +95,8 @@ class TestSatelliteData(unittest.TestCase):
             long_fieldname='Long')
         self.assertEqual(len(observations.data), 1)
         self.assertEqual(observations.data[0]["id"], "p3")
-        #self.assertEqual(observations.data[0].get("Number"), None)
-        self.assertEqual(observations.add_warning.called, True)
-        observations.add_warning.assert_called_with('multiple_sat_matches')
+        self.assertEqual(observations.data[0].get("Number"), 444)
+        self.assertEqual(observations.add_warning.called, False)
 
     @patch("satellitedata.pd")
     @patch("satellitedata.LANDCOVER_SATELLITE_URL")


### PR DESCRIPTION
When joining RGB or Landcoverage satellite data with iNaturalist observations and multiple regions are found return the region that has the closest centroid. Also adds code to display all observation columns adding horizontal scrolling support and making the label column sticky.

Fixes #46
Fixes #47