### PR TITLE
Join with the nearest satellite location

### DIFF
--- a/andromeda-ui/components/ObservationTable.tsx
+++ b/andromeda-ui/components/ObservationTable.tsx
@@ -7,18 +7,39 @@ interface ObservationTableProps {
 }
 
 const TH_CLASSNAME = "p-2 border text-slate-500 font-semi-bold text-sm"
-const TD_CLASSNAME = "p-1 border text-slate-500 text-sm"
+const TD_CLASSNAME = "p-1 border text-slate-500 text-sm whitespace-nowrap text-ellipsis"
+const KNOWN_COLUMNS = new Set([
+    "Image_Label",
+    "Image_Link",
+    "Date",
+    "Time",
+    "Lat",
+    "Long",
+    "Species",
+    "Place",
+    "Seconds",
+    "User"
+]);
 
 export default function ObservationTable(props: ObservationTableProps) {
     const { observations, maxObs, iNatUser } = props;
     const showing = Math.min(observations.length, maxObs);
+    let extraColumns: string[] = [];
+    if (observations.length > 0) {
+        extraColumns = Object.keys(observations[0]).filter((x) => !KNOWN_COLUMNS.has(x))
+    }
     const rows = observations.slice(0, maxObs).map((x) => {
+        const extraColumnValues = extraColumns.map(colname => {
+            return <td key={colname + "_" + x.Image_Label} className={TD_CLASSNAME}>
+                {x[colname]}
+            </td>;
+        })
         return <tr key={x.Image_Label}>
-            <td className={TD_CLASSNAME}>{x.Image_Label}</td>
+            <td className={TD_CLASSNAME + " sticky left-0 bg-white"}>{x.Image_Label}</td>
             <td className={TD_CLASSNAME}>
                 <Image
-                    width="64"
-                    height="64"
+                    width={50}
+                    height={50}
                     src={x.Image_Link}
                     alt={x.Image_Label}
                     title={x.Image_Link} />
@@ -47,31 +68,38 @@ export default function ObservationTable(props: ObservationTableProps) {
             <td className={TD_CLASSNAME}>
                 {x.User}
             </td>
+            {extraColumnValues}
         </tr>
     });
+    const extraColumnHeaders = extraColumns.map(colname => {
+        return <th key={colname} className={TH_CLASSNAME}>{colname}</th>;
+    })
     return <>
         <div className="my-1">
             <span className="text-lg flex-auto">Observations by {iNatUser}</span>
         </div>
-        <table className="border-collapse border">
-            <thead className="bg-slate-50 border-slate-400">
-                <tr>
-                    <th className={TH_CLASSNAME}>Image_Label</th>
-                    <th className={TH_CLASSNAME}>Image_Link</th>
-                    <th className={TH_CLASSNAME}>Date</th>
-                    <th className={TH_CLASSNAME}>Time</th>
-                    <th className={TH_CLASSNAME}>Lat</th>
-                    <th className={TH_CLASSNAME}>Long</th>
-                    <th className={TH_CLASSNAME}>Species</th>
-                    <th className={TH_CLASSNAME}>Place</th>
-                    <th className={TH_CLASSNAME}>Seconds</th>
-                    <th className={TH_CLASSNAME}>User</th>
-                </tr>
-            </thead>
-            <tbody>
-                {rows}
-            </tbody>
-        </table>
+        <div className="overflow-auto">
+            <table className="border-collapse border table-auto">
+                <thead className="bg-slate-50 border-slate-400">
+                    <tr>
+                        <th className={TH_CLASSNAME+ " sticky left-0 bg-slate-50"}>Image_Label</th>
+                        <th className={TH_CLASSNAME}>Image_Link</th>
+                        <th className={TH_CLASSNAME}>Date</th>
+                        <th className={TH_CLASSNAME}>Time</th>
+                        <th className={TH_CLASSNAME}>Lat</th>
+                        <th className={TH_CLASSNAME}>Long</th>
+                        <th className={TH_CLASSNAME}>Species</th>
+                        <th className={TH_CLASSNAME}>Place</th>
+                        <th className={TH_CLASSNAME}>Seconds</th>
+                        <th className={TH_CLASSNAME}>User</th>
+                        {extraColumnHeaders}
+                    </tr>
+                </thead>
+                <tbody>
+                    {rows}
+                </tbody>
+            </table>
+        </div>
         <span className="text-sm">
             Showing {showing} rows ({observations.length} in total)
         </span>

--- a/andromeda/satellitedata.py
+++ b/andromeda/satellitedata.py
@@ -46,7 +46,8 @@ def find_satellite_records(sat_df, sat_geo_series, lat, long, column_prefix):
 
 def merge_lat_long_csv_url(observations, lat_fieldname, long_fieldname, column_prefix, url):
     sat_df, sat_geo_series = read_satellite_data(url)
-    observations.add_fieldnames(list(sat_df.columns))
+    new_fieldnames = list(sat_df.columns) + [f"{column_prefix}_in", f"{column_prefix}_distance"]
+    observations.add_fieldnames(new_fieldnames)
     has_a_match = False
     for obs in observations.data:
         lat = obs[lat_fieldname]

--- a/andromeda/tests/test_satellitedata.py
+++ b/andromeda/tests/test_satellitedata.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 from satellitedata import (
     add_satellite_rgb_data,
     add_satellite_landcover_data,
+    find_satellite_records,
     LAT_NW, LAT_SE, LON_NW, LON_SE
 )
 
@@ -14,8 +15,8 @@ def sample_rgb_dataframe():
     data = [
         (40.332624,	-74.749758,	40.313732,	-74.707701, 111),
         (40.365821,	-74.76289,	40.345643,	-74.720636, 222),
-        (32, 32, 28, 28, 333),
-        (31, 31, 27, 27, 444),
+        (31, 31, 27, 27, 333),
+        (32, 32, 28, 28, 444),
     ]
     return pd.DataFrame.from_records(data, columns=columns)
 
@@ -41,6 +42,54 @@ def sample_observation_data():
 class TestSatelliteData(unittest.TestCase):
     @patch("satellitedata.pd")
     @patch("satellitedata.RGB_SATELLITE_URL")
+    def test_add_satellite_rgb_data_distance(self, mock_rgb_url, mock_pd):
+        columns = [LAT_NW, LON_NW, LAT_SE, LON_SE, "Number"]
+        data = [
+            (31, 31, 27, 27, 111),
+            (32, 32, 30, 30, 222),
+        ]
+        mock_pd.read_csv.return_value = pd.DataFrame.from_records(data, columns=columns)
+        observation_data = [
+            { # Center of 111
+                "id": "p1",
+                "Lat": 29,
+                "Long": 29
+            },
+            { # Just outside of 111
+                "id": "p2",
+                "Lat": 27,
+                "Long": 29
+            },
+            { # Center of of 222
+                "id": "p3",
+                "Lat": 31,
+                "Long": 31
+            },
+        ]
+        observations = Mock(data=observation_data)
+        add_satellite_rgb_data(
+            observations=observations,
+            lat_fieldname='Lat',
+            long_fieldname='Long')
+        self.assertEqual(len(observations.data), 3)
+        obs = observations.data[0]
+        self.assertEqual(obs["id"], "p1")
+        self.assertEqual(obs["Number"], 111)
+        self.assertEqual(obs["sat_in"], 1)
+        self.assertEqual(obs["sat_distance"], 0)
+        obs = observations.data[1]
+        self.assertEqual(obs["id"], "p2")
+        self.assertEqual(obs["Number"], 111)
+        self.assertEqual(obs["sat_in"], 0)
+        self.assertEqual(obs["sat_distance"], 2.0)
+        obs = observations.data[2]
+        self.assertEqual(obs["id"], "p3")
+        self.assertEqual(obs["Number"], 222)
+        self.assertEqual(obs["sat_in"], 1)
+        self.assertEqual(obs["sat_distance"], 0)
+
+    @patch("satellitedata.pd")
+    @patch("satellitedata.RGB_SATELLITE_URL")
     def test_add_satellite_rgb_data(self, mock_rgb_url, mock_pd):
         sat_df = sample_rgb_dataframe()
         mock_pd.read_csv.return_value = sat_df
@@ -52,15 +101,21 @@ class TestSatelliteData(unittest.TestCase):
         self.assertEqual(len(observations.data), 3)
         self.assertEqual(observations.data[0]["id"], "p1")
         self.assertEqual(observations.data[0]["Number"], 111)
+        self.assertEqual(observations.data[0]["sat_in"], 1)
+        self.assertLess(observations.data[0]["sat_distance"], 0.1)
         self.assertEqual(observations.data[1]["id"], "p2")
         self.assertEqual(observations.data[1]["Number"], 222)
+        self.assertEqual(observations.data[1]["sat_in"], 1)
+        self.assertLess(observations.data[1]["sat_distance"], 0.1)
         self.assertEqual(observations.data[2]["id"], "p3")
-        self.assertEqual(observations.data[2].get("Number"), None)
+        self.assertEqual(observations.data[2].get("Number"), 111)
+        self.assertEqual(observations.data[2]["sat_in"], 0)
+        self.assertLess(observations.data[2]["sat_distance"], 0.1)
         self.assertEqual(observations.add_warning.called, False)
         mock_pd.read_csv.assert_called_with(mock_rgb_url)
 
     @patch("satellitedata.pd")
-    def test_add_satellite_rgb_data_no_match(self, mock_pd):
+    def test_add_satellite_rgb_data_not_in_region(self, mock_pd):
         sat_df = sample_rgb_dataframe()
         mock_pd.read_csv.return_value = sat_df
         unmatched_lat_long_data = [{
@@ -75,9 +130,9 @@ class TestSatelliteData(unittest.TestCase):
             long_fieldname='Long')
         self.assertEqual(len(observations.data), 1)
         self.assertEqual(observations.data[0]["id"], "p3")
-        self.assertEqual(observations.data[0].get("Number"), None)
-        self.assertEqual(observations.add_warning.called, True)
-        observations.add_warning.assert_called_with('no_sat_matches')
+        self.assertEqual(observations.data[0].get("Number"), 111)
+        self.assertEqual(observations.data[0]["sat_in"], 0)
+        self.assertEqual(observations.add_warning.called, False)
 
     @patch("satellitedata.pd")
     def test_add_satellite_rgb_data_duplicates(self, mock_pd):
@@ -95,9 +150,8 @@ class TestSatelliteData(unittest.TestCase):
             long_fieldname='Long')
         self.assertEqual(len(observations.data), 1)
         self.assertEqual(observations.data[0]["id"], "p3")
-        #self.assertEqual(observations.data[0].get("Number"), None)
-        self.assertEqual(observations.add_warning.called, True)
-        observations.add_warning.assert_called_with('multiple_sat_matches')
+        self.assertEqual(observations.data[0].get("Number"), 444)
+        self.assertEqual(observations.add_warning.called, False)
 
     @patch("satellitedata.pd")
     @patch("satellitedata.LANDCOVER_SATELLITE_URL")
@@ -115,6 +169,6 @@ class TestSatelliteData(unittest.TestCase):
         self.assertEqual(observations.data[1]["id"], "p2")
         self.assertEqual(observations.data[1]["Number"], 222)
         self.assertEqual(observations.data[2]["id"], "p3")
-        self.assertEqual(observations.data[2].get("Number"), None)
+        self.assertEqual(observations.data[2].get("Number"), 111)
         self.assertEqual(observations.add_warning.called, False)
         mock_pd.read_csv.assert_called_with(mock_lc_url)

--- a/andromeda/tests/test_satellitedata.py
+++ b/andromeda/tests/test_satellitedata.py
@@ -87,6 +87,10 @@ class TestSatelliteData(unittest.TestCase):
         self.assertEqual(obs["Number"], 222)
         self.assertEqual(obs["sat_in"], 1)
         self.assertEqual(obs["sat_distance"], 0)
+        observations.add_fieldnames.assert_called_with([
+            'sat_Lat-NW', 'sat_Lon-NW', 'sat_Lat-SE', 'sat_Lon-SE', 'Number',
+            'sat_in', 'sat_distance']
+        )
 
     @patch("satellitedata.pd")
     @patch("satellitedata.RGB_SATELLITE_URL")


### PR DESCRIPTION
Joins iNaturalist observations with satellite data by choosing the satellite region's center that is closest to the observation location. Adds four new columns to resulting CSV/JSON:
- `sat_in` - Added when joining RGB satellite data - values 1 or 0
- `sat_distance` - Added when joining RGB satellite data - distance from observation to closest region centroid
- `land_type_in` - Added when joining land coverage data - values 1 or 0
- `land_type_distance` - Added when joining land coverage data - distance from observation to closest region centroid

Also adds code to display all observation columns adding horizontal scrolling support and making the label column sticky.

Fixes #46
Fixes #47