### PR TITLE
Add note about sat data being Quest 2023

### DIFF
--- a/andromeda-ui/components/FetchDataForm.tsx
+++ b/andromeda-ui/components/FetchDataForm.tsx
@@ -39,5 +39,8 @@ export default function FetchDataForm(props: FetchDataFormProps) {
         <div className="my-2">
             <ColoredButton disabled={disableFetchButton} label="Fetch Observations" color="blue" onClick={onClickFetch} />
         </div>
+        <p className="text-sm mt-4" >
+            Note: The RGB and landcover satellite data is specific to the Princeton, NJ area, as it was developed for QUEST 2023.
+        </p>
     </>;
 }


### PR DESCRIPTION
Fixes #51

This is what the fetch data page looks like with the message added:
<img width="842" alt="Screen Shot 2023-07-14 at 8 08 46 AM" src="https://github.com/Imageomics/Andromeda/assets/1024463/a2d51ab5-a01f-4283-892f-e4242a893df9">
