### PR TITLE
Improve ease of use for QUEST 2023

### DIFF
--- a/andromeda-ui/backend/dataset.ts
+++ b/andromeda-ui/backend/dataset.ts
@@ -66,3 +66,7 @@ export function calculatePointScaling(images: any[]) {
     return 1.0; // default scaling
   }
 }
+
+export async function getColumnConfig() {
+  return await fetch_json(apiURL("/column-config"), {});
+}

--- a/andromeda-ui/backend/parseCSV.ts
+++ b/andromeda-ui/backend/parseCSV.ts
@@ -1,23 +1,5 @@
 import Papa from "papaparse";
 
-const DEFAULT_UNSELECTED_COLUMNS = new Set([
-  "sat_Lat-Center",
-  "sat_Lon-Center",
-  "sat_Lat-NW",
-  "sat_Lon-NW",
-  "sat_Lat-SE",
-  "sat_Lon-SE",
-  "land_Lat-Center",
-  "land_Lon-Center",
-  "land_Lat-NW",
-  "land_Lon-NW",
-  "land_Lat-SE",
-  "land_Lon-SE",
-  "sat_in",
-  "land_in",
-  "Seconds"
-])
-
 export async function parseCSVFile(file: File) {
   // Wrap Papa.parse in a promise to allow async/await usage
   const promise: any = new Promise((resolve, reject) => {
@@ -121,25 +103,27 @@ export function createColumnDetails(rows: any[]) {
   };
 }
 
-function isDefaultSelectedColName(colName: string) {
-  return !DEFAULT_UNSELECTED_COLUMNS.has(colName);
+export function groupColumnsByType(columns: string[], ancillaryColumnSet: Set<string>) {
+  return {
+      regularColumns: columns.filter((colname) => !ancillaryColumnSet.has(colname)),
+      ancillaryColumns: columns.filter((colname) => ancillaryColumnSet.has(colname))
+  };
 }
 
-export function getDefaultSelectedColumns(columnDetails: any) {
-  const selectedColumns = columnDetails.columns.slice();
-  return selectedColumns.filter(isDefaultSelectedColName);
-}
-
-export function createColumnSettings(columnDetails: any) {
+export function createColumnSettings(columnDetails: any, columnConfig: any) {
   // column settings are the user adjustable values
   // that determine how the CSV file is used by the MDS code
   let url = undefined;
   if (columnDetails.urls.length > 0) {
     url = columnDetails.urls[0];
   }
+  const { regularColumns, ancillaryColumns} = groupColumnsByType(
+    columnDetails.columns,
+    new Set(columnConfig.ancillary_columns));
   return {
     label: columnDetails.labels[0],
     url: url,
-    selected: getDefaultSelectedColumns(columnDetails),
+    selected: regularColumns,
+    ancillaryColumns: ancillaryColumns
   };
 }

--- a/andromeda-ui/backend/parseCSV.ts
+++ b/andromeda-ui/backend/parseCSV.ts
@@ -1,5 +1,23 @@
 import Papa from "papaparse";
 
+const DEFAULT_UNSELECTED_COLUMNS = new Set([
+  "sat_Lat-Center",
+  "sat_Lon-Center",
+  "sat_Lat-NW",
+  "sat_Lon-NW",
+  "sat_Lat-SE",
+  "sat_Lon-SE",
+  "land_Lat-Center",
+  "land_Lon-Center",
+  "land_Lat-NW",
+  "land_Lon-NW",
+  "land_Lat-SE",
+  "land_Lon-SE",
+  "sat_in",
+  "land_in",
+  "Seconds"
+])
+
 export async function parseCSVFile(file: File) {
   // Wrap Papa.parse in a promise to allow async/await usage
   const promise: any = new Promise((resolve, reject) => {
@@ -103,6 +121,15 @@ export function createColumnDetails(rows: any[]) {
   };
 }
 
+function isDefaultSelectedColName(colName: string) {
+  return !DEFAULT_UNSELECTED_COLUMNS.has(colName);
+}
+
+export function getDefaultSelectedColumns(columnDetails: any) {
+  const selectedColumns = columnDetails.columns.slice();
+  return selectedColumns.filter(isDefaultSelectedColName);
+}
+
 export function createColumnSettings(columnDetails: any) {
   // column settings are the user adjustable values
   // that determine how the CSV file is used by the MDS code
@@ -113,6 +140,6 @@ export function createColumnSettings(columnDetails: any) {
   return {
     label: columnDetails.labels[0],
     url: url,
-    selected: columnDetails.columns.slice(),
+    selected: getDefaultSelectedColumns(columnDetails),
   };
 }

--- a/andromeda-ui/components/ConfigureDataset.tsx
+++ b/andromeda-ui/components/ConfigureDataset.tsx
@@ -1,7 +1,7 @@
 import SimpleSelect from "../components/SimpleSelect";
 import SelectColumnsList from "../components/SelectColumnsList";
 import ColoredButton from './ColoredButton';
-import { showError } from "../util/toast";
+import { groupColumnsByType } from "../backend/parseCSV";
 
 interface ConfigureDatasetProps {
     columnDetails: any;
@@ -39,6 +39,21 @@ export default function ConfigureDataset(props: ConfigureDatasetProps) {
             setValue={setURLColumnName}
             values={columnDetails.urls} />
     }
+    const {regularColumns, ancillaryColumns} = groupColumnsByType(
+        columnDetails.columns,
+        new Set(columnSettings.ancillaryColumns)
+    )
+
+    let selectAncillaryColumns = null;
+    if (ancillaryColumns.length) {
+        selectAncillaryColumns = <>
+            <div className="text-md font-medium">Ancillary Columns</div>
+            <SelectColumnsList
+                columns={ancillaryColumns}
+                selectedColumns={columnSettings.selected}
+                changeSelectedColumn={changeSelectedColumn} />
+        </>
+    }
 
     return <div>
         <h2 className="text-xl mb-2 font-bold">Configure Visualization</h2>
@@ -56,9 +71,10 @@ export default function ConfigureDataset(props: ConfigureDatasetProps) {
         <div>
             <div className="text-md font-medium">Columns</div>
             <SelectColumnsList
-                columns={columnDetails.columns}
+                columns={regularColumns}
                 selectedColumns={columnSettings.selected}
                 changeSelectedColumn={changeSelectedColumn} />
+            {selectAncillaryColumns}
         </div>
         <div className="mt-4 flex gap-2">
             <ColoredButton

--- a/andromeda-ui/components/ObservationTable.tsx
+++ b/andromeda-ui/components/ObservationTable.tsx
@@ -28,7 +28,10 @@ export default function ObservationTable(props: ObservationTableProps) {
     if (observations.length > 0) {
         extraColumns = Object.keys(observations[0]).filter((x) => !KNOWN_COLUMNS.has(x))
     }
-    const rows = observations.slice(0, maxObs).map((x) => {
+    // since the default order of observations is date ascending reverse
+    // show we are showing the most recent observations
+    const exampleObservations = observations.slice().reverse().slice(0, maxObs);
+    const rows = exampleObservations.map((x) => {
         const extraColumnValues = extraColumns.map(colname => {
             return <td key={colname + "_" + x.Image_Label} className={TD_CLASSNAME}>
                 {x[colname]}

--- a/andromeda-ui/components/SelectColumnsList.tsx
+++ b/andromeda-ui/components/SelectColumnsList.tsx
@@ -17,7 +17,6 @@ function groupItems(items: string[], size: number) {
 
 export default function SelectColumnsList(props: SelectColumnsListrProps) {
     const { columns, selectedColumns, changeSelectedColumn } = props
-    const items = columns.slice();
     const groupedItems = groupItems(columns, CHECKBOXES_PER_ROW)
     const columnTableRows = groupedItems.map((columnNamesSubset: string[], idx: number) => {
         console.log(idx, columnNamesSubset);
@@ -39,7 +38,7 @@ export default function SelectColumnsList(props: SelectColumnsListrProps) {
             {checkboxes}
         </tr>
     });
-    return <table className="">
+    return <table className="ml-1">
         <tbody>
             {columnTableRows}
         </tbody>

--- a/andromeda-ui/components/SelectColumnsList.tsx
+++ b/andromeda-ui/components/SelectColumnsList.tsx
@@ -1,4 +1,4 @@
-const CHECKBOXES_PER_ROW = 10;
+const CHECKBOXES_PER_ROW = 6;
 
 interface SelectColumnsListrProps {
     columns: string[];

--- a/andromeda-ui/pages/index.tsx
+++ b/andromeda-ui/pages/index.tsx
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic'
 import { uploadDataset, dimensionalReduction, reverseDimensionalReduction,
-  calculatePointScaling } from "../backend/dataset";
+  calculatePointScaling, getColumnConfig } from "../backend/dataset";
 import React, { useState } from 'react';
 import UploadFile from '../components/UploadFile';
 import ConfigureDataset from "../components/ConfigureDataset";
@@ -27,7 +27,8 @@ export default function Home() {
       const result = await uploadDataset(selectedFile);
       const rows = await parseCSVFile(selectedFile);
       const details = createColumnDetails(rows);
-      const settings = createColumnSettings(details);
+      const columnConfig = await getColumnConfig();
+      const settings = createColumnSettings(details, columnConfig);
       setDatasetID(result.id);
       setColumnDetails(details);
       setColumnSettings(settings);
@@ -84,10 +85,6 @@ export default function Home() {
       const initialWeights = { all: 1.0 / columnSettings.selected.length };
       await performDimensionalReduction(datasetID, initialWeights);
     }
-  }
-
-  function selectedFileChanged() {
-
   }
 
   let content = null;

--- a/andromeda-ui/tests/backend/parseCSV.test.ts
+++ b/andromeda-ui/tests/backend/parseCSV.test.ts
@@ -1,4 +1,4 @@
-import { createColumnDetails, getDefaultSelectedColumns } from "../../backend/parseCSV";
+import { createColumnDetails, groupColumnsByType } from "../../backend/parseCSV";
 
 test("createColumnDetails removes columns containing a single value", () => {
   const rows = [
@@ -49,9 +49,8 @@ test("createColumnDetails can find URL columns", () => {
 });
 
 
-test("getDefaultSelectedColumns filters out specific columns",() => {
-  const result = getDefaultSelectedColumns({
-    "columns": [
+test("groupColumnsByType groups columns appropriately",() => {
+  const result = groupColumnsByType([
       // columns to keep
       "Image_Label", "Image_Link", "Date", "Time",
       "Lat", "Long", "Species",
@@ -64,11 +63,25 @@ test("getDefaultSelectedColumns filters out specific columns",() => {
       "Seconds",
       // column to keep
       "Other"
-    ]
-  })
-  expect(result).toStrictEqual([
+  ],
+  new Set([ // ancillary columns
+    "sat_Lat-Center", "sat_Lon-Center",
+    "sat_Lat-NW", "sat_Lon-NW", "sat_Lat-SE", "sat_Lon-SE",
+    "land_Lat-Center", "land_Lon-Center",
+    "land_Lat-NW", "land_Lon-NW", "land_Lat-SE", "land_Lon-SE", "sat_in", "land_in",
+    "Seconds"
+  ]))
+  expect(result.regularColumns).toStrictEqual([
     "Image_Label", "Image_Link", "Date", "Time",
       "Lat", "Long", "Species",
       "sat_good", "land_good", "Other"
   ]);
+  expect(result.ancillaryColumns).toStrictEqual([
+    "sat_Lat-Center", "sat_Lon-Center",
+    "sat_Lat-NW", "sat_Lon-NW", "sat_Lat-SE", "sat_Lon-SE",
+    "land_Lat-Center", "land_Lon-Center",
+    "land_Lat-NW", "land_Lon-NW", "land_Lat-SE", "land_Lon-SE", "sat_in", "land_in",
+    "Seconds"
+  ]);
+
 });

--- a/andromeda-ui/tests/backend/parseCSV.test.ts
+++ b/andromeda-ui/tests/backend/parseCSV.test.ts
@@ -1,4 +1,4 @@
-import { createColumnDetails } from "../../backend/parseCSV";
+import { createColumnDetails, getDefaultSelectedColumns } from "../../backend/parseCSV";
 
 test("createColumnDetails removes columns containing a single value", () => {
   const rows = [
@@ -46,4 +46,29 @@ test("createColumnDetails can find URL columns", () => {
   expect(result.labels).toStrictEqual(["Label", "NumGood"]);
   expect(result.columns).toStrictEqual(["NumGood"]);
   expect(result.urls).toStrictEqual(["GoodURL"]);
+});
+
+
+test("getDefaultSelectedColumns filters out specific columns",() => {
+  const result = getDefaultSelectedColumns({
+    "columns": [
+      // columns to keep
+      "Image_Label", "Image_Link", "Date", "Time",
+      "Lat", "Long", "Species",
+      "sat_good", "land_good",
+      // columns to remove
+      "sat_Lat-Center", "sat_Lon-Center",
+      "sat_Lat-NW", "sat_Lon-NW", "sat_Lat-SE", "sat_Lon-SE",
+      "land_Lat-Center", "land_Lon-Center",
+      "land_Lat-NW", "land_Lon-NW", "land_Lat-SE", "land_Lon-SE", "sat_in", "land_in",
+      "Seconds",
+      // column to keep
+      "Other"
+    ]
+  })
+  expect(result).toStrictEqual([
+    "Image_Label", "Image_Link", "Date", "Time",
+      "Lat", "Long", "Species",
+      "sat_good", "land_good", "Other"
+  ]);
 });

--- a/andromeda/README.md
+++ b/andromeda/README.md
@@ -138,3 +138,13 @@ Read all observations for iNaturalist user and return as a CSV file.
     ...
     ```
 NOTE: Since the result is a CSV file no warnings will be returned.
+
+### Get column configuration settings
+Retrieve configuration about ancillary column names
+- GET __/api/column-config/__
+  - Output
+    ```
+     "ancillary_columns": [
+        "sat_Lat-Center", ...
+     ]
+    ```

--- a/andromeda/columnConfig.json
+++ b/andromeda/columnConfig.json
@@ -1,0 +1,21 @@
+{
+    "ancillary_columns": [
+        "sat_Lat-Center",
+        "sat_Lon-Center",
+        "sat_Lat-NW",
+        "sat_Lon-NW",
+        "sat_Lat-SE",
+        "sat_Lon-SE",
+        "land_Lat-Center",
+        "land_Lon-Center",
+        "land_Lat-NW",
+        "land_Lon-NW",
+        "land_Lat-SE",
+        "land_Lon-SE",
+        "sat_in",
+        "land_in",
+        "sat_distance",
+        "land_distance",
+        "Seconds"
+    ]
+}

--- a/andromeda/main.py
+++ b/andromeda/main.py
@@ -1,4 +1,5 @@
 import os
+import json
 import datetime
 from flask import Flask, Response, request, jsonify, abort, json
 from werkzeug.exceptions import HTTPException
@@ -7,6 +8,8 @@ from dataset import DatasetStore
 from inaturalist import get_inaturalist_observations, create_csv_str
 
 UPLOAD_FOLDER = os.environ.get('ANDROMEDA_UPLOAD_DIR', '/tmp/andromeda_uploads')
+COLUMN_CONFIG = os.environ.get('ANDROMEDA_COLUMN_CONFIG', 'columnConfig.json')
+
 app = Flask(__name__)
 if os.environ.get('ANDROMEDA_DEV_MODE'):
     print("Warning: Disabling CORS checking for local development.")
@@ -135,3 +138,10 @@ def csv_reponse_for_observations(fieldnames, observations, user_id):
         mimetype="text/csv",
         headers={"Content-disposition":
                 f"attachment; filename=andromeda_inaturalist_{user_id}_{now_str}.csv"})        
+
+
+@app.route('/api/column-config', methods=['GET'])
+def get_column_config():
+    with open(COLUMN_CONFIG, 'r') as infile:
+        payload = json.load(infile)
+    return jsonify(payload)

--- a/andromeda/tests/test_main.py
+++ b/andromeda/tests/test_main.py
@@ -138,3 +138,9 @@ class TestDataset(unittest.TestCase):
         result = client.get(f"/api/inaturalist/bob?format=json&add_landcover_data=true")
         self.assertEqual(result.status_code, 200)
         mock_get_inaturalist_observations.assert_called_with(user_id='bob', add_sat_rgb_data=False, add_landcover_data=True)
+
+    def test_get_get_column_config(self):
+        client = app.test_client()
+        result = client.get(f"/api/column-config")
+        self.assertEqual(result.status_code, 200)
+        self.assertIn("ancillary_columns", result.json.keys())


### PR DESCRIPTION
Changes fetching observations logic to sort INaturalist observations to show the most recent observation.
Unchecks specific columns to simplify use in QUEST 2023.
Changes number of columns displayed on each row from 10 to 6 to make the screen easier to read.

Fixes #54