### PR TITLE
Zoom image grid to fit images

### DIFF
--- a/andromeda-ui/backend/dataset.ts
+++ b/andromeda-ui/backend/dataset.ts
@@ -1,5 +1,7 @@
 import { fetch_json, apiURL } from "./util";
 
+const IMAGE_GRID_MAX_VALUE = 1.0;
+
 export async function uploadDataset(file: File) {
   const formData = new FormData();
   formData.append("file", file);
@@ -49,4 +51,18 @@ export async function reverseDimensionalReduction(
       body: JSON.stringify(data),
     }
   );
+}
+
+export function calculatePointScaling(images: any[]) {
+  const max_abs_x = Math.max(...images.map(img => Math.abs(img.x)));
+  const max_abs_y = Math.max(...images.map(img => Math.abs(img.y)));
+  const max_x_y_value = Math.max(max_abs_x, max_abs_y);
+  // the image grid top left is 1,1 and the bottom right is -1,-1
+  // the maximum displayable abs(value) is 1 (IMAGE_GRID_MAX_VALUE)
+  // if the points already fit we do not need to scale the points
+  if (max_x_y_value > IMAGE_GRID_MAX_VALUE) {
+    return 1.0 / max_x_y_value;
+  } else {
+    return 1.0; // default scaling
+  }
 }

--- a/andromeda-ui/components/DataExplorer.tsx
+++ b/andromeda-ui/components/DataExplorer.tsx
@@ -8,13 +8,14 @@ import ImageGrid from "../components/ImageGrid";
 import { useState, useRef } from 'react';
 
 const DEFAULT_IMAGE_SIZE = 40;
-const DEFAULT_POINT_SCALING = 1.0;
-const GRID_SIZE = 600;
+const GRID_SIZE = 500;
 const THUMBNAIL_SIZE = 100;
 
 interface DataExplorerProps {
     images: any[];
     setImageData: any;
+    pointScaling: number;
+    setPointScaling: (scaling: number) => void
     weights: any | undefined;
     datasetID: string | undefined;
     columnSettings: any;
@@ -25,9 +26,10 @@ interface DataExplorerProps {
 
 
 export default function DataExplorer(props: DataExplorerProps) {
-    const { images, setImageData, weights, datasetID, columnSettings, drFunc, rdrFunc, onClickBack } = props;
+    const { images, setImageData, pointScaling, setPointScaling,
+        weights, datasetID, columnSettings,
+        drFunc, rdrFunc, onClickBack } = props;
     const [imageSize, setImageSize] = useState<number>(DEFAULT_IMAGE_SIZE);
-    const [pointScaling, setPointScaling] = useState<number>(DEFAULT_POINT_SCALING);
     const [showLabel, setShowLabel] = useState<boolean>(true);
     const [showImage, setShowImage] = useState<boolean>(true);
     const [sliderWeights, setSliderWeights] = useState<any>(weights);
@@ -127,7 +129,7 @@ export default function DataExplorer(props: DataExplorerProps) {
                     onImageMoved={onImageMoved}
                     images={images}
                 />
-                <div className="flex gap-2 my-2">
+                <div className="flex gap-2 my-2 mr-2">
                     <ColoredButton
                         label="Back"
                         disabled={false}

--- a/andromeda-ui/components/ImageGrid.tsx
+++ b/andromeda-ui/components/ImageGrid.tsx
@@ -72,7 +72,8 @@ export default function ImageGrid(props: ImageGridProps) {
         props.onImageMoved(x, y, label);
     }
 
-    return <Stage ref={stageRef} draggable={true} width={size} height={size}
+    return <Stage ref={stageRef} draggable={true}
+        width={size + imageSize} height={size + imageSize}
         className="cursor-grab border border-black mr-2">
         <Layer>
             <Rect width={size} height={size} />

--- a/andromeda-ui/pages/index.tsx
+++ b/andromeda-ui/pages/index.tsx
@@ -1,5 +1,6 @@
 import dynamic from 'next/dynamic'
-import { uploadDataset, dimensionalReduction, reverseDimensionalReduction } from "../backend/dataset";
+import { uploadDataset, dimensionalReduction, reverseDimensionalReduction,
+  calculatePointScaling } from "../backend/dataset";
 import React, { useState } from 'react';
 import UploadFile from '../components/UploadFile';
 import ConfigureDataset from "../components/ConfigureDataset";
@@ -11,6 +12,7 @@ const DataExplorer = dynamic(() => import("../components/DataExplorer"), {
 import { showError } from "../util/toast";
 import { parseCSVFile, createColumnDetails, createColumnSettings } from "../backend/parseCSV";
 
+const DEFAULT_POINT_SCALING = 1.0;
 
 export default function Home() {
   const [datasetID, setDatasetID] = useState<string>();
@@ -18,6 +20,7 @@ export default function Home() {
   const [weightData, setWeightData] = useState<any[]>();
   const [columnDetails, setColumnDetails] = useState<any>();
   const [columnSettings, setColumnSettings] = useState<any>();
+  const [pointScaling, setPointScaling] = useState<number>(DEFAULT_POINT_SCALING);
 
   async function uploadFile(selectedFile: any) {
     try {
@@ -53,6 +56,7 @@ export default function Home() {
     try {
       const result = await dimensionalReduction(id, weights, columnSettings)
       setDatasetID(id);
+      setPointScaling(calculatePointScaling(result.images));
       setImageData(result.images);
       setWeightData(result.weights);
       return result;
@@ -99,6 +103,8 @@ export default function Home() {
           rdrFunc={performReverseDimensionalReduction}
           columnSettings={columnSettings}
           onClickBack={showEditConfig}
+          pointScaling={pointScaling}
+          setPointScaling={setPointScaling}
         />
       </>;
   } else {

--- a/andromeda-ui/tests/backend/dataset.test.ts
+++ b/andromeda-ui/tests/backend/dataset.test.ts
@@ -1,0 +1,31 @@
+import { calculatePointScaling } from "../../backend/dataset";
+
+jest.mock('next/config', () => () => ({
+    publicRuntimeConfig: {
+        apiURL: 'https://example.com/api'
+    }
+}))
+
+test("calculatePointScaling when points larger than 1", () => {
+    const result = calculatePointScaling([
+        { x: 0.5, y: 0.3},
+        { x: 2, y: 4}
+    ])
+    expect(result).toEqual(0.25);
+});
+
+test("calculatePointScaling when points really large", () => {
+    const result = calculatePointScaling([
+        { x: 10, y: 4}
+    ])
+    expect(result).toEqual(0.1);
+});
+
+test("calculatePointScaling when points less than 1", () => {
+    const result = calculatePointScaling([
+        { x: 0.5, y: 0.3},
+        { x: 0.75, y: 0.5},
+        
+    ])
+    expect(result).toEqual(1.0);
+});


### PR DESCRIPTION
Adds logic that will automatically update the zoom slider so all images will be visible. Updates the image grid to have a larger margin to better display images that are close to the edge.

Fixes #31