### PR TITLE
Add dynamic landcover data

### DIFF
--- a/andromeda-ui/backend/observations.ts
+++ b/andromeda-ui/backend/observations.ts
@@ -2,9 +2,9 @@ import { fetch_json, apiURL } from "./util";
 
 export const LANDCOVER_FETCH_SECONDS = 5;
 
-export async function fetchObservations(iNatUser: string, addLandCover: boolean,
+export async function fetchObservations(iNatUser: string, addCustomSatData: boolean, addLandCover: boolean,
   maxObs: number) {
-    const url = makeObservationURL(iNatUser, addLandCover, "json", maxObs);
+    const url = makeObservationURL(iNatUser, addCustomSatData, addLandCover, "json", maxObs);
     return await fetch_json(url, {
       method: "GET",
       headers: {
@@ -13,12 +13,13 @@ export async function fetchObservations(iNatUser: string, addLandCover: boolean,
     });
 }
 
-export function makeObservationURL(iNatUser: string, addLandCover: boolean, 
+export function makeObservationURL(iNatUser: string, addCustomSatData: boolean, addLandCover: boolean,
       format: "json" | "csv", maxObs?: number) {
   let base_url = "/inaturalist/" + iNatUser + "?format=" + format;
   if (maxObs) {
     base_url += "&limit=" + maxObs;
   }
+  base_url += "&add_custom_sat_data=" + addCustomSatData;
   base_url += "&add_landcover_data=" + addLandCover;
   return apiURL(base_url);
 }
@@ -30,4 +31,14 @@ export function downloadSecondsEstimate(numObservations: number) {
   } else {
     return Math.ceil(seconds / 60) + " minutes"
   }
+}
+
+export async function getCustomDataConfig() {
+  const url = apiURL('/custom-data-config')
+  return await fetch_json(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
 }

--- a/andromeda-ui/backend/observations.ts
+++ b/andromeda-ui/backend/observations.ts
@@ -1,7 +1,8 @@
 import { fetch_json, apiURL } from "./util";
 
-export async function fetchObservations(iNatUser: string, addSatRGB: boolean, addLandCover: boolean) {
-    const url = makeObservationURL(iNatUser, addSatRGB, addLandCover, "json");
+export async function fetchObservations(iNatUser: string, addLandCover: boolean,
+  maxObs: number) {
+    const url = makeObservationURL(iNatUser, addLandCover, "json", maxObs);
     return await fetch_json(url, {
       method: "GET",
       headers: {
@@ -10,12 +11,21 @@ export async function fetchObservations(iNatUser: string, addSatRGB: boolean, ad
     });
 }
 
-export function makeObservationURL(iNatUser: string, addSatRGB: boolean, addLandCover: boolean, format: "json" | "csv") {
-  let base_url = "/inaturalist/" + iNatUser;
-  if (format) {
-    base_url += "?format=" + format;
+export function makeObservationURL(iNatUser: string, addLandCover: boolean, 
+      format: "json" | "csv", maxObs?: number) {
+  let base_url = "/inaturalist/" + iNatUser + "?format=" + format;
+  if (maxObs) {
+    base_url += "&limit=" + maxObs;
   }
-  base_url += "&add_sat_rgb_data=" + addSatRGB;
   base_url += "&add_landcover_data=" + addLandCover;
   return apiURL(base_url);
+}
+
+export function downloadSecondsEstimate(numObservations: number) {
+  const seconds = numObservations * 5;
+  if (seconds < 60) {
+    return seconds + "seconds";
+  } else {
+    return Math.ceil(seconds / 60) + " minutes"
+  }
 }

--- a/andromeda-ui/backend/observations.ts
+++ b/andromeda-ui/backend/observations.ts
@@ -1,5 +1,7 @@
 import { fetch_json, apiURL } from "./util";
 
+export const LANDCOVER_FETCH_SECONDS = 5;
+
 export async function fetchObservations(iNatUser: string, addLandCover: boolean,
   maxObs: number) {
     const url = makeObservationURL(iNatUser, addLandCover, "json", maxObs);
@@ -22,7 +24,7 @@ export function makeObservationURL(iNatUser: string, addLandCover: boolean,
 }
 
 export function downloadSecondsEstimate(numObservations: number) {
-  const seconds = numObservations * 5;
+  const seconds = numObservations * LANDCOVER_FETCH_SECONDS;
   if (seconds < 60) {
     return seconds + "seconds";
   } else {

--- a/andromeda-ui/backend/observations.ts
+++ b/andromeda-ui/backend/observations.ts
@@ -42,3 +42,21 @@ export async function getCustomDataConfig() {
     },
   });
 }
+
+export function makeObservationDatasetURL(iNatUser: string, addCustomSatData: boolean, addLandCover: boolean) {
+  let url = `/inaturalist/${iNatUser}/dataset?` + 
+            `add_custom_sat_data=${addCustomSatData}&add_landcover_data=${addLandCover}`;
+  return apiURL(url);
+}
+
+export async function createObservationDataset(iNatUser: string, addCustomSatData: boolean,
+      addLandCover: boolean) {
+      const url = makeObservationDatasetURL(iNatUser, addCustomSatData, addLandCover);
+      console.log(url);
+      return await fetch_json(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        }
+      });
+}

--- a/andromeda-ui/components/Anchor.tsx
+++ b/andromeda-ui/components/Anchor.tsx
@@ -1,0 +1,13 @@
+import { PropsWithChildren } from 'react'
+
+interface AnchorProps {
+    href: string;
+    target: string;
+}
+
+export default function Anchor(props: PropsWithChildren<AnchorProps>) {
+    const {href, target, children} = props;
+    return <a className="underline text-blue-600 hover:text-blue-800 visited:text-purple-600" href={href} target={target}>
+        {children}
+    </a>
+}

--- a/andromeda-ui/components/ColoredButton.tsx
+++ b/andromeda-ui/components/ColoredButton.tsx
@@ -1,18 +1,26 @@
 import {buttonColorClassName} from "./ButtonColors";
+import Spinner from "./Spinner";
 
 interface ColoredButtonProps {
     label: string;
     onClick: any;
     disabled?: boolean;
     color: string;
+    spinnerOnDisabled?: boolean;
 }
 
 export default function ColoredButton(props: ColoredButtonProps) {
-    const { label, disabled, color, onClick } = props;
+    const { label, disabled, color, spinnerOnDisabled, onClick } = props;
     const className = buttonColorClassName(color);
+    let beforeLabel = null;
+    if (disabled && spinnerOnDisabled) {
+        beforeLabel = <Spinner />;
+    }
     return <button
         onClick={onClick}
         disabled={disabled}
         className={className}
-        type="button">{label}</button>;
+        type="button">
+            {beforeLabel}{label}
+        </button>;
 }

--- a/andromeda-ui/components/DownloadFileButton.tsx
+++ b/andromeda-ui/components/DownloadFileButton.tsx
@@ -1,11 +1,16 @@
 import {buttonColorClassName} from "./ButtonColors";
+import Spinner from "./Spinner";
 
 interface DownloadFileButtonProps {
-    url: string;
+    url: string | undefined;
 }
 
 export default function DownloadFileButton(props: DownloadFileButtonProps) {
     const { url } = props;
     const className = buttonColorClassName("blue");
-    return <a className={className} download href={url}>Download CSV</a>;
+    if (url) {
+        return <a className={className} download href={url}>Download CSV</a>;
+    } else {
+        return <button className={className} disabled><Spinner /> Download CSV</button>;
+    }
 }

--- a/andromeda-ui/components/FetchDataForm.tsx
+++ b/andromeda-ui/components/FetchDataForm.tsx
@@ -1,5 +1,6 @@
 import ColoredButton from "../components/ColoredButton";
 import LatLonCoverNote from "../components/LatLonCoverNote";
+import {LANDCOVER_FETCH_SECONDS} from "../backend/observations";
 
 interface FetchDataFormProps {
     iNatUser: string | undefined;
@@ -29,7 +30,7 @@ export default function FetchDataForm(props: FetchDataFormProps) {
         
             <label title={LAND_COVER_TOOLTIP} className="mr-2 text-md font-medium" htmlFor="AddLandCover">Landcover Satellite Data:</label>
             <input title={LAND_COVER_TOOLTIP} className="accent-cyan-600" type="checkbox" id="AddLandCover" checked={addLandCover} onChange={onChangeLand}></input>
-            <span className="ml-2 text-sm italic align-text-bottom">(takes ~5 seconds per observation)</span>
+            <span className="ml-2 text-sm italic align-text-bottom">(takes ~{LANDCOVER_FETCH_SECONDS} seconds per observation)</span>
         </div>
         <div className="my-2">
             <ColoredButton spinnerOnDisabled={true} disabled={disableFetchButton} label="Fetch Observations" color="blue" onClick={onClickFetch} />

--- a/andromeda-ui/components/FetchDataForm.tsx
+++ b/andromeda-ui/components/FetchDataForm.tsx
@@ -9,7 +9,7 @@ interface FetchDataFormProps {
     onClickFetch: () => void;
     addLandCover: boolean;
     setAddLandCover: (add: boolean) => void;
-    customSataDataConfig: any | null;
+    customSatDataConfig: any | null;
     addCustomSatData: boolean;
     setAddCustomSatData: (add: boolean) => void;
 }
@@ -18,7 +18,7 @@ const LAND_COVER_TOOLTIP = "Add small and big landcoverage classification column
 
 export default function FetchDataForm(props: FetchDataFormProps) {
     const {iNatUser, setINatUser, disableFetchButton, onClickFetch, addLandCover, setAddLandCover,
-        customSataDataConfig, addCustomSatData, setAddCustomSatData} = props;
+        customSatDataConfig, addCustomSatData, setAddCustomSatData} = props;
     function onChangeLand(event: any){
         setAddLandCover(event.target.checked)
     }
@@ -27,10 +27,10 @@ export default function FetchDataForm(props: FetchDataFormProps) {
     }
     let customSatDataDiv = null;
     let customSatDataNote = null;
-    if (customSataDataConfig) {
+    if (customSatDataConfig) {
         customSatDataDiv = <div className="py-1">
             <label className="mr-2 text-md font-medium" htmlFor="AddCustomSatData">
-                    {customSataDataConfig.label}:
+                    {customSatDataConfig.label}:
                 </label>
                 <input
                     type="checkbox" id="AddCustomSatData"
@@ -38,9 +38,9 @@ export default function FetchDataForm(props: FetchDataFormProps) {
                     onChange={onChangeAddCustomSatData}>
                 </input>
         </div>
-        if (customSataDataConfig.note) {
+        if (customSatDataConfig.note) {
             customSatDataNote = <p className="text-sm mt-4 max-w-prose" >
-                {customSataDataConfig.note}
+                {customSatDataConfig.note}
             </p>
         }
     }

--- a/andromeda-ui/components/FetchDataForm.tsx
+++ b/andromeda-ui/components/FetchDataForm.tsx
@@ -9,15 +9,42 @@ interface FetchDataFormProps {
     onClickFetch: () => void;
     addLandCover: boolean;
     setAddLandCover: (add: boolean) => void;
+    customSataDataConfig: any | null;
+    addCustomSatData: boolean;
+    setAddCustomSatData: (add: boolean) => void;
 }
 
 const LAND_COVER_TOOLTIP = "Add small and big landcoverage classification columns."
 
 export default function FetchDataForm(props: FetchDataFormProps) {
-    const {iNatUser, setINatUser, disableFetchButton, onClickFetch, addLandCover, setAddLandCover} = props;
+    const {iNatUser, setINatUser, disableFetchButton, onClickFetch, addLandCover, setAddLandCover,
+        customSataDataConfig, addCustomSatData, setAddCustomSatData} = props;
     function onChangeLand(event: any){
         setAddLandCover(event.target.checked)
     }
+    function onChangeAddCustomSatData(event: any){
+        setAddCustomSatData(event.target.checked)
+    }
+    let customSatDataDiv = null;
+    let customSatDataNote = null;
+    if (customSataDataConfig) {
+        customSatDataDiv = <div className="py-1">
+            <label className="mr-2 text-md font-medium" htmlFor="AddCustomSatData">
+                    {customSataDataConfig.label}:
+                </label>
+                <input
+                    type="checkbox" id="AddCustomSatData"
+                    checked={addCustomSatData}
+                    onChange={onChangeAddCustomSatData}>
+                </input>
+        </div>
+        if (customSataDataConfig.note) {
+            customSatDataNote = <p className="text-sm mt-4 max-w-prose" >
+                {customSataDataConfig.note}
+            </p>
+        }
+    }
+
     return <>
         <p className="max-w-2xl text-sm my-2">
             Find iNaturalist observations to create a CSV file that can be visualized in Andromeda.
@@ -27,14 +54,19 @@ export default function FetchDataForm(props: FetchDataFormProps) {
             <input className="mr-4 border rounded p-1" type="text" id="iNatUser" name="iNatUser" required
                 value={iNatUser}
                 onChange={(e: any) => setINatUser(e.target.value)} />
-        
-            <label title={LAND_COVER_TOOLTIP} className="mr-2 text-md font-medium" htmlFor="AddLandCover">Landcover Satellite Data:</label>
+        </div>
+        <div className="py-1">
+            <label title={LAND_COVER_TOOLTIP} className="mr-2 text-md font-medium" htmlFor="AddLandCover">
+                Add Landcover Satellite Data:
+            </label>
             <input title={LAND_COVER_TOOLTIP} className="accent-cyan-600" type="checkbox" id="AddLandCover" checked={addLandCover} onChange={onChangeLand}></input>
             <span className="ml-2 text-sm italic align-text-bottom">(takes ~{LANDCOVER_FETCH_SECONDS} seconds per observation)</span>
         </div>
+        {customSatDataDiv}
         <div className="my-2">
             <ColoredButton spinnerOnDisabled={true} disabled={disableFetchButton} label="Fetch Observations" color="blue" onClick={onClickFetch} />
         </div>
         <LatLonCoverNote />
+        {customSatDataNote}
     </>;
 }

--- a/andromeda-ui/components/FetchDataForm.tsx
+++ b/andromeda-ui/components/FetchDataForm.tsx
@@ -1,22 +1,19 @@
 import ColoredButton from "../components/ColoredButton";
+import LatLonCoverNote from "../components/LatLonCoverNote";
 
 interface FetchDataFormProps {
     iNatUser: string | undefined;
     setINatUser: (user: string) => void;
     disableFetchButton: boolean;
     onClickFetch: () => void;
-    addSatRGBData: boolean;
-    setAddSatRGBData: (add: boolean) => void;
     addLandCover: boolean;
     setAddLandCover: (add: boolean) => void;
 }
 
+const LAND_COVER_TOOLTIP = "Add small and big landcoverage classification columns."
+
 export default function FetchDataForm(props: FetchDataFormProps) {
-    const {iNatUser, setINatUser, disableFetchButton, onClickFetch, 
-        addSatRGBData, setAddSatRGBData, addLandCover, setAddLandCover} = props;
-    function onChangeCSV(event: any){
-        setAddSatRGBData(event.target.checked)
-    }
+    const {iNatUser, setINatUser, disableFetchButton, onClickFetch, addLandCover, setAddLandCover} = props;
     function onChangeLand(event: any){
         setAddLandCover(event.target.checked)
     }
@@ -30,17 +27,13 @@ export default function FetchDataForm(props: FetchDataFormProps) {
                 value={iNatUser}
                 onChange={(e: any) => setINatUser(e.target.value)} />
         
-            <label className="mr-2 text-md font-medium" htmlFor="AddSatCSV">RGB Satellite Data:</label>
-            <input className="mr-4 accent-cyan-600" type="checkbox" id="AddSatCSV" checked={addSatRGBData} onChange={onChangeCSV}></input>
-    
-            <label className="mr-2 text-md font-medium" htmlFor="AddLandCover">Landcover Satellite Data:</label>
-            <input className="accent-cyan-600" type="checkbox" id="AddLandCover" checked={addLandCover} onChange={onChangeLand}></input>
+            <label title={LAND_COVER_TOOLTIP} className="mr-2 text-md font-medium" htmlFor="AddLandCover">Landcover Satellite Data:</label>
+            <input title={LAND_COVER_TOOLTIP} className="accent-cyan-600" type="checkbox" id="AddLandCover" checked={addLandCover} onChange={onChangeLand}></input>
+            <span className="ml-2 text-sm italic align-text-bottom">(takes ~5 seconds per observation)</span>
         </div>
         <div className="my-2">
-            <ColoredButton disabled={disableFetchButton} label="Fetch Observations" color="blue" onClick={onClickFetch} />
+            <ColoredButton spinnerOnDisabled={true} disabled={disableFetchButton} label="Fetch Observations" color="blue" onClick={onClickFetch} />
         </div>
-        <p className="text-sm mt-4" >
-            Note: The RGB and landcover satellite data is specific to the Princeton, NJ area, as it was developed for QUEST 2023.
-        </p>
+        <LatLonCoverNote />
     </>;
 }

--- a/andromeda-ui/components/LatLonCoverNote.tsx
+++ b/andromeda-ui/components/LatLonCoverNote.tsx
@@ -1,0 +1,20 @@
+import Anchor from "../components/Anchor";
+
+export default function LatLonCoverNote() {
+    return <p className="text-sm mt-4 max-w-prose" >
+        Note:
+        The landcover satellite data is only available for the contiguous United States 
+        from 2022 and is generated using&nbsp;
+        <Anchor href="https://github.com/Imageomics/LatLonCover" target="_blank">LatLonCover</Anchor>.
+        Columns will be added for landcover data at two scales centered on each observation geocoordinate:
+        &nbsp;
+        <span className="italic" title="1/2 x 1/2 mile">small</span>
+        &nbsp;and&nbsp;
+        <span className="italic" title="2 x 2 mile">big</span>.
+        See&nbsp;
+        <Anchor href="https://github.com/Imageomics/LatLonCover/blob/main/cropScapeDocumentation/CDL_subcategories_legendCrse.csv" target="_blank">
+        LatLonCover subcategories
+        </Anchor>
+        &nbsp;for the definitions of the classifications.
+    </p>
+}

--- a/andromeda-ui/components/ObservationTable.tsx
+++ b/andromeda-ui/components/ObservationTable.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image'
 interface ObservationTableProps {
     iNatUser: string | undefined;
     observations: any[];
+    totalObservations: number;
     maxObs: number;
 }
 
@@ -22,15 +23,13 @@ const KNOWN_COLUMNS = new Set([
 ]);
 
 export default function ObservationTable(props: ObservationTableProps) {
-    const { observations, maxObs, iNatUser } = props;
+    const { observations, maxObs, iNatUser, totalObservations } = props;
     const showing = Math.min(observations.length, maxObs);
     let extraColumns: string[] = [];
     if (observations.length > 0) {
         extraColumns = Object.keys(observations[0]).filter((x) => !KNOWN_COLUMNS.has(x))
     }
-    // since the default order of observations is date ascending reverse
-    // show we are showing the most recent observations
-    const exampleObservations = observations.slice().reverse().slice(0, maxObs);
+    const exampleObservations = observations.slice().slice(0, maxObs);
     const rows = exampleObservations.map((x) => {
         const extraColumnValues = extraColumns.map(colname => {
             return <td key={colname + "_" + x.Image_Label} className={TD_CLASSNAME}>
@@ -106,7 +105,7 @@ export default function ObservationTable(props: ObservationTableProps) {
             </table>
         </div>
         <span className="text-sm">
-            Showing {showing} rows ({observations.length} in total)
+            Showing {showing} rows ({totalObservations} in total)
         </span>
 
     </>;

--- a/andromeda-ui/components/Spinner.tsx
+++ b/andromeda-ui/components/Spinner.tsx
@@ -1,0 +1,6 @@
+export default function Spinner() {
+    return <svg className="inline animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>;
+}

--- a/andromeda-ui/pages/fetch-data/index.tsx
+++ b/andromeda-ui/pages/fetch-data/index.tsx
@@ -38,12 +38,12 @@ export default function GeneratePage() {
     const [observations, setObservations] = useState<any[]>([]);
     const [totalObservations, setTotalObservations] = useState<number>(0);
     const [loaded, setLoaded] = useState<boolean>(false);
-    const [customSataDataConfig, setCustomSataDataConfig] = useState<any>();
+    const [customSatDataConfig, setCustomSatDataConfig] = useState<any>();
 
     useEffect(() => {
         const fetchData = async () => {
           const result = await getCustomDataConfig()
-          setCustomSataDataConfig(result);
+          setCustomSatDataConfig(result);
           setLoaded(true);
         };
         fetchData().catch(console.error);
@@ -119,7 +119,7 @@ export default function GeneratePage() {
                     setINatUser={setINatUser}
                     addLandCover={addLandCover}
                     setAddLandCover={setAddLandCover}
-                    customSataDataConfig={customSataDataConfig}
+                    customSatDataConfig={customSatDataConfig}
                     addCustomSatData={addCustomSatData}
                     setAddCustomSatData={setAddCustomSatData}
                     disableFetchButton={fetching}

--- a/andromeda-ui/pages/fetch-data/index.tsx
+++ b/andromeda-ui/pages/fetch-data/index.tsx
@@ -6,7 +6,7 @@ import FetchDataForm from "../../components/FetchDataForm";
 import WarningNotice from "../../components/WarningNotice";
 import Main from "../../components/Main";
 import { fetchObservations, makeObservationURL, downloadSecondsEstimate,
-    getCustomDataConfig } from "../../backend/observations";
+    getCustomDataConfig, createObservationDataset } from "../../backend/observations";
 import { useState, useEffect, use } from 'react';
 import { showError } from "../../util/toast";
 
@@ -39,6 +39,9 @@ export default function GeneratePage() {
     const [totalObservations, setTotalObservations] = useState<number>(0);
     const [loaded, setLoaded] = useState<boolean>(false);
     const [customSatDataConfig, setCustomSatDataConfig] = useState<any>();
+    const [generateObservationDataset, setGenerateObservationDataset] = useState<boolean>(false);
+    const [observationsURL, setObservationsURL] = useState<string>();
+
 
     useEffect(() => {
         const fetchData = async () => {
@@ -48,6 +51,17 @@ export default function GeneratePage() {
         };
         fetchData().catch(console.error);
       }, []);
+
+    useEffect(() => {
+        const createDataset = async () => {
+            if (generateObservationDataset) {
+                const result = await createObservationDataset(iNatUser, addCustomSatData, addLandCover)
+                setObservationsURL(result.url);
+                setGenerateObservationDataset(false);
+            }
+        };
+        createDataset().catch(console.error);
+    }, [generateObservationDataset]);
 
     async function onClickFetch() {
         if (iNatUser) {
@@ -66,6 +80,7 @@ export default function GeneratePage() {
                         setShowObservations(false);
                     } else {
                         setShowObservations(true);
+                        setGenerateObservationDataset(true);
                     }
                 }
             } catch (error: any) {
@@ -93,7 +108,7 @@ export default function GeneratePage() {
     if (addLandCover) {
         const estimatedTimeMsg = downloadSecondsEstimate(totalObservations);
         downloadingNote = <span className="py-2 ml-2 text-sm italic align-text-bottom">
-            NOTE: Downloading will take ~ {estimatedTimeMsg} for this dataset due to fetching landcover data.
+            NOTE: Generating the CSV for all observations will take ~ {estimatedTimeMsg} due to fetching landcover data.
         </span>;
     }
     if (showObservations) {
@@ -107,7 +122,7 @@ export default function GeneratePage() {
             {warningNotice}
             <div className="flex gap-2 my-2">
                 <ColoredButton label="Back" color="white" onClick={onClickBack} />
-                <DownloadFileButton url={csvURL}  />
+                <DownloadFileButton url={observationsURL}  />
                 {downloadingNote}
             </div>
         </div>;
@@ -133,6 +148,7 @@ export default function GeneratePage() {
         <TitleBar selected="/fetch-data" />
         <Main>
             {content}
+
         </Main>
     </>;
 }

--- a/andromeda/README.md
+++ b/andromeda/README.md
@@ -24,7 +24,7 @@ Andromeda has support for including a custom satellite CSV dataset that users ca
 See [quest-2023-RGB-customData.json](../datasets/satelliteData/quest-2023-RGB-customData.json) for an example.
 
  
-To activate the custom dataset functionality set the `ANDROMEDA_CUSTOM_DATA`.
+To activate the custom dataset functionality set the `ANDROMEDA_CUSTOM_DATA` environment variable.
 For example to activate the `quest-2023-RGB-customData.json` run the following before running the app.
 ```
 export ANDROMEDA_CUSTOM_DATA=../datasets/satelliteData/quest-2023-RGB-customData.json

--- a/andromeda/README.md
+++ b/andromeda/README.md
@@ -14,6 +14,22 @@ Install depenencies within a python virtual environment:
 pip install -r requirements.txt
 ```
 
+## Custom Dataset
+Andromeda has support for including a custom satellite CSV dataset that users can merge their iNaturalist observation data with. The dataset must have 4 columns representing the lat/lon bounding box to compare against the observation lat/lon. To use this feature a JSON config file must be provided with the following items:
+- label - Label for checkbox in UI describing the CSV dataset
+- note - Note about the dataset
+- column_prefix - prefix to add column names during merging
+- fields - dictionary of LAT_NW,LON_NW,LAT_SE,LON_SE referencing the bounding box columns in the CSV dataset
+
+See [quest-2023-RGB-customData.json](../datasets/satelliteData/quest-2023-RGB-customData.json) for an example.
+
+ 
+To activate the custom dataset functionality set the `ANDROMEDA_CUSTOM_DATA`.
+For example to activate the `quest-2023-RGB-customData.json` run the following before running the app.
+```
+export ANDROMEDA_CUSTOM_DATA=../datasets/satelliteData/quest-2023-RGB-customData.json
+```
+
 ## Running
 
 By default flask performs CORS checking which is useful in production.
@@ -147,4 +163,23 @@ Retrieve configuration about ancillary column names
      "ancillary_columns": [
         "sat_Lat-Center", ...
      ]
+    ```
+
+### Get custom dataset configuration
+Retrieve config settings for the custom satellite dataset
+- GET __/api/custom-data-config/__
+  - Example Output
+    ```
+    {
+        "label": "Add RGB Satellite Data",
+        "note": "Note: The RGB satellite data is specific to the Princeton, NJ area, as it was developed for QUEST 2023.",
+        "column_prefix": "sat",
+        "fields": {
+            "LAT_NW": "sat_Lat-NW",
+            "LON_NW": "sat_Lon-NW",
+            "LAT_SE": "sat_Lat-SE",
+            "LON_SE": "sat_Lon-SE"
+        },
+        "url": "https://raw.githubusercontent.com/Imageomics/Andromeda/main/datasets/satelliteData/satRgbFinal4.csv"
+    }
     ```

--- a/andromeda/dataset.py
+++ b/andromeda/dataset.py
@@ -9,10 +9,20 @@ class DatasetStore(object):
     def __init__(self, base_directory):
         self.base_directory = base_directory
 
-    def create_dataset(self, csv_file):
+    def _create_new_Dataset(self):
         dataset_id = str(uuid.uuid4())
         dataset = Dataset(dataset_id, self.base_directory)
+        return dataset
+
+    def create_dataset(self, csv_file):
+        dataset = self._create_new_Dataset()
         csv_file.save(dataset.get_path())
+        return dataset
+
+    def create_dataset_with_content(self, csv_content):
+        dataset = self._create_new_Dataset()
+        with open(dataset.get_path(), 'w') as outfile:
+            outfile.write(csv_content)
         return dataset
 
     def get_dataset(self, dataset_id, column_settings):
@@ -26,6 +36,10 @@ class DatasetStore(object):
         if not dataset.exists():
             abort(404, f"No dataset found for id {dataset_id}.")
         return dataset
+    
+    def get_dataset_path(self, dataset_id):
+        dataset = Dataset(dataset_id, self.base_directory)
+        return dataset.get_path()
 
 
 class Dataset(object):

--- a/andromeda/inaturalist.py
+++ b/andromeda/inaturalist.py
@@ -2,7 +2,7 @@ import io
 import csv
 import pandas as pd
 import pyinaturalist
-from satellitedata import add_satellite_rgb_data, add_satellite_landcover_data
+from satellitedata import add_custom_satellite_data, add_satellite_landcover_data
 
 LABEL_FIELD = "Image_Label"
 URL_FIELD = "Image_Link"
@@ -77,7 +77,7 @@ def get_label(idx, total_observations, reversed):
     return f"p{num}"
 
 
-def get_inaturalist_observations(user_id, add_sat_rgb_data, add_landcover_data, limit):
+def get_inaturalist_observations(user_id, add_custom_sat_data, add_landcover_data, limit):
     idx = 0
     missing_lat_long = False
     obeservation_ary, total_observations = get_observations(user_id=user_id, limit=limit)
@@ -126,8 +126,8 @@ def get_inaturalist_observations(user_id, add_sat_rgb_data, add_landcover_data, 
     if missing_lat_long:
         observations.add_warning("missing_lat_long")
 
-    if add_sat_rgb_data:
-        add_satellite_rgb_data(observations, LAT_FIELD, LON_FIELD)
+    if add_custom_sat_data:
+        add_custom_satellite_data(observations, LAT_FIELD, LON_FIELD)
 
     if add_landcover_data:
         add_satellite_landcover_data(observations, LAT_FIELD, LON_FIELD)

--- a/andromeda/inaturalist.py
+++ b/andromeda/inaturalist.py
@@ -64,7 +64,7 @@ def get_observations(user_id, limit=None):
         # when using per_page the observations are sorted with the most recent first
         observations_dict = pyinaturalist.get_observations(user_id=user_id, per_page=limit)
     else:
-        # when using per_page the observations are sorted descending
+        # when using page="all" the observations are sorted descending
         observations_dict = pyinaturalist.get_observations(user_id=user_id, page="all")
     return observations_dict["results"], total_observations
 

--- a/andromeda/main.py
+++ b/andromeda/main.py
@@ -13,7 +13,7 @@ COLUMN_CONFIG = os.environ.get('ANDROMEDA_COLUMN_CONFIG', 'columnConfig.json')
 app = Flask(__name__)
 if os.environ.get('ANDROMEDA_DEV_MODE'):
     print("Warning: Disabling CORS checking for local development.")
-    CORS(app, origins=["http://127.0.0.1:3000"]) # Disable CORS so local react app can use the API
+    CORS(app, origins=["http://localhost:3000"]) # Disable CORS so local react app can use the API
 os.makedirs(UPLOAD_FOLDER, exist_ok=True) # ensure the upload destination exists
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 app.config['MAX_CONTENT_LENGTH'] = 200 * 1024 * 1024  # 200 MB

--- a/andromeda/main.py
+++ b/andromeda/main.py
@@ -6,9 +6,11 @@ from werkzeug.exceptions import HTTPException
 from flask_cors import CORS
 from dataset import DatasetStore
 from inaturalist import get_inaturalist_observations, create_csv_str, BadObservationException
+from satellitedata import get_custom_sat_data_config
 
 UPLOAD_FOLDER = os.environ.get('ANDROMEDA_UPLOAD_DIR', '/tmp/andromeda_uploads')
 COLUMN_CONFIG = os.environ.get('ANDROMEDA_COLUMN_CONFIG', 'columnConfig.json')
+
 
 app = Flask(__name__)
 if os.environ.get('ANDROMEDA_DEV_MODE'):
@@ -117,12 +119,12 @@ def inverse_dimensional_reduction(dataset_id):
 @app.route('/api/inaturalist/<user_id>', methods=['GET'])
 def get_inaturalist(user_id):
     format = request.args.get("format", "json").lower()
-    add_sat_rgb_data = get_boolean_param(request, "add_sat_rgb_data")
+    add_custom_sat_data = get_boolean_param(request, "add_custom_sat_data")
     add_landcover_data = get_boolean_param(request, "add_landcover_data")
     limit = get_int_param(request, "limit")
     try:
         observations = get_inaturalist_observations(user_id=user_id,
-                                                    add_sat_rgb_data=add_sat_rgb_data,
+                                                    add_custom_sat_data=add_custom_sat_data,
                                                     add_landcover_data=add_landcover_data,
                                                     limit=limit)
         if format == "json":
@@ -158,3 +160,8 @@ def get_column_config():
     with open(COLUMN_CONFIG, 'r') as infile:
         payload = json.load(infile)
     return jsonify(payload)
+
+
+@app.route('/api/custom-data-config', methods=['GET'])
+def get_custom_data_config():
+    return jsonify(get_custom_sat_data_config())

--- a/andromeda/requirements.txt
+++ b/andromeda/requirements.txt
@@ -1,6 +1,7 @@
-pandas==2.0.0
+pandas==2.0.3
 scikit-learn==1.2.2
 Flask==2.3.2
 Flask-Cors==3.0.10
 pyinaturalist==0.18.0
 geopandas==0.13.2
+latloncover==0.1.0

--- a/andromeda/requirements.txt
+++ b/andromeda/requirements.txt
@@ -1,7 +1,7 @@
 pandas==2.0.3
 scikit-learn==1.2.2
 Flask==2.3.2
-Flask-Cors==3.0.10
+Flask-Cors==4.0.0
 pyinaturalist==0.18.0
 geopandas==0.13.2
 latloncover==0.1.0

--- a/andromeda/tests/test_inaturalist.py
+++ b/andromeda/tests/test_inaturalist.py
@@ -39,7 +39,7 @@ class TestINaturalist(unittest.TestCase):
         mock_get_observations.return_value = ([item], 1)
 
         observations = get_inaturalist_observations(user_id="user-1",
-                                                    add_sat_rgb_data=False,
+                                                    add_custom_sat_data=False,
                                                     add_landcover_data=False,
                                                     limit=None)
         self.assertEqual(len(observations.data), 1)
@@ -58,37 +58,37 @@ class TestINaturalist(unittest.TestCase):
     def test_get_inaturalist_observations_with_limit(self, mock_get_observations):
         mock_get_observations.return_value = ([], 1)
         get_inaturalist_observations(user_id="user-1",
-                                     add_sat_rgb_data=False,
+                                     add_custom_sat_data=False,
                                      add_landcover_data=False,
                                      limit=10)
         mock_get_observations.assert_called_with(user_id='user-1', limit=10)
 
     @patch("inaturalist.get_observations")
-    @patch("inaturalist.add_satellite_rgb_data")
+    @patch("inaturalist.add_custom_satellite_data")
     @patch("inaturalist.add_satellite_landcover_data")
-    def test_get_inaturalist_observations_rgb(self, mock_add_satellite_landcover_data,
-                                              mock_add_satellite_rgb_data,
-                                              mock_get_observations):
+    def test_get_inaturalist_observations_custom(self, mock_add_satellite_landcover_data,
+                                                 mock_add_custom_satellite_data,
+                                                 mock_get_observations):
         mock_get_observations.return_value = ([], 0)
         observations = get_inaturalist_observations(user_id="user-1",
-                                                    add_sat_rgb_data=True,
+                                                    add_custom_sat_data=True,
                                                     add_landcover_data=False,
                                                     limit=None)
-        mock_add_satellite_rgb_data.assert_called_with(observations, 'Lat', 'Long')
+        mock_add_custom_satellite_data.assert_called_with(observations, 'Lat', 'Long')
         mock_add_satellite_landcover_data.assert_not_called()
 
     @patch("inaturalist.get_observations")
-    @patch("inaturalist.add_satellite_rgb_data")
+    @patch("inaturalist.add_custom_satellite_data")
     @patch("inaturalist.add_satellite_landcover_data")
     def test_get_inaturalist_observations_landcover(self, mock_add_satellite_landcover_data,
-                                                    mock_add_satellite_rgb_data,
+                                                    mock_add_custom_satellite_data,
                                                     mock_get_observations):
         mock_get_observations.return_value = ([], 0)
         observations = get_inaturalist_observations(user_id="user-1",
-                                                    add_sat_rgb_data=False,
+                                                    add_custom_sat_data=False,
                                                     add_landcover_data=True,
                                                     limit=None)
-        mock_add_satellite_rgb_data.assert_not_called()
+        mock_add_custom_satellite_data.assert_not_called()
         mock_add_satellite_landcover_data.assert_called_with(observations, 'Lat', 'Long')
 
     @patch("inaturalist.get_observations")
@@ -105,7 +105,7 @@ class TestINaturalist(unittest.TestCase):
         mock_get_observations.return_value = ([item], 1)
 
         observations = get_inaturalist_observations(user_id="user-1",
-                                                    add_sat_rgb_data=False,
+                                                    add_custom_sat_data=False,
                                                     add_landcover_data=False,
                                                     limit=None)
         self.assertEqual(len(observations.data), 1)
@@ -137,7 +137,7 @@ class TestINaturalist(unittest.TestCase):
         with self.assertRaises(BadObservationException) as raised_exception:
             get_inaturalist_observations(
                 user_id="user-1",
-                add_sat_rgb_data=False,
+                add_custom_sat_data=False,
                 add_landcover_data=False,
                 limit=None)
         self.assertEqual(str(raised_exception.exception), OBSERVED_ON_MISSING_MSG)

--- a/andromeda/tests/test_inaturalist.py
+++ b/andromeda/tests/test_inaturalist.py
@@ -5,7 +5,10 @@ from inaturalist import (
     get_inaturalist_observations,
     create_csv_str,
     BadObservationException,
-    OBSERVED_ON_MISSING_MSG
+    OBSERVED_ON_MISSING_MSG,
+    get_label,
+    count_observerations,
+    get_observations
 )
 
 
@@ -33,11 +36,12 @@ class TestINaturalist(unittest.TestCase):
             "user": {"login": "bob"},
             "species_guess": "Equus grevyi",
         }
-        mock_get_observations.return_value = {"results": [item]}
+        mock_get_observations.return_value = ([item], 1)
 
         observations = get_inaturalist_observations(user_id="user-1",
                                                     add_sat_rgb_data=False,
-                                                    add_landcover_data=False)
+                                                    add_landcover_data=False,
+                                                    limit=None)
         self.assertEqual(len(observations.data), 1)
         first_obs = observations.data[0]
         self.assertEqual(first_obs.keys(), set(expected_columns))
@@ -51,15 +55,25 @@ class TestINaturalist(unittest.TestCase):
         self.assertEqual(observations.warnings, set())
 
     @patch("inaturalist.get_observations")
+    def test_get_inaturalist_observations_with_limit(self, mock_get_observations):
+        mock_get_observations.return_value = ([], 1)
+        get_inaturalist_observations(user_id="user-1",
+                                     add_sat_rgb_data=False,
+                                     add_landcover_data=False,
+                                     limit=10)
+        mock_get_observations.assert_called_with(user_id='user-1', limit=10)
+
+    @patch("inaturalist.get_observations")
     @patch("inaturalist.add_satellite_rgb_data")
     @patch("inaturalist.add_satellite_landcover_data")
     def test_get_inaturalist_observations_rgb(self, mock_add_satellite_landcover_data,
                                               mock_add_satellite_rgb_data,
                                               mock_get_observations):
-        mock_get_observations.return_value = {"results": []}
+        mock_get_observations.return_value = ([], 0)
         observations = get_inaturalist_observations(user_id="user-1",
                                                     add_sat_rgb_data=True,
-                                                    add_landcover_data=False)
+                                                    add_landcover_data=False,
+                                                    limit=None)
         mock_add_satellite_rgb_data.assert_called_with(observations, 'Lat', 'Long')
         mock_add_satellite_landcover_data.assert_not_called()
 
@@ -69,10 +83,11 @@ class TestINaturalist(unittest.TestCase):
     def test_get_inaturalist_observations_landcover(self, mock_add_satellite_landcover_data,
                                                     mock_add_satellite_rgb_data,
                                                     mock_get_observations):
-        mock_get_observations.return_value = {"results": []}
+        mock_get_observations.return_value = ([], 0)
         observations = get_inaturalist_observations(user_id="user-1",
                                                     add_sat_rgb_data=False,
-                                                    add_landcover_data=True)
+                                                    add_landcover_data=True,
+                                                    limit=None)
         mock_add_satellite_rgb_data.assert_not_called()
         mock_add_satellite_landcover_data.assert_called_with(observations, 'Lat', 'Long')
 
@@ -87,11 +102,12 @@ class TestINaturalist(unittest.TestCase):
             "species_guess": "Equus grevyi",
         }
 
-        mock_get_observations.return_value = {"results": [item]}
+        mock_get_observations.return_value = ([item], 1)
 
         observations = get_inaturalist_observations(user_id="user-1",
                                                     add_sat_rgb_data=False,
-                                                    add_landcover_data=False)
+                                                    add_landcover_data=False,
+                                                    limit=None)
         self.assertEqual(len(observations.data), 1)
         self.assertEqual(observations.warnings,set(["missing_lat_long"]))
 
@@ -116,11 +132,42 @@ class TestINaturalist(unittest.TestCase):
             "user": {"login": "bob"},
             "species_guess": "Equus grevyi",
         }
-        mock_get_observations.return_value = {"results": [item]}
+        mock_get_observations.return_value = ([item], 1)
 
         with self.assertRaises(BadObservationException) as raised_exception:
             get_inaturalist_observations(
                 user_id="user-1",
                 add_sat_rgb_data=False,
-                add_landcover_data=False)
+                add_landcover_data=False,
+                limit=None)
         self.assertEqual(str(raised_exception.exception), OBSERVED_ON_MISSING_MSG)
+
+    def test_get_label(self):
+        self.assertEqual(get_label(idx=0, total_observations=10, reversed=False), "p1")
+        self.assertEqual(get_label(idx=1, total_observations=10, reversed=False), "p2")
+        self.assertEqual(get_label(idx=0, total_observations=10, reversed=True), "p10")
+        self.assertEqual(get_label(idx=1, total_observations=20, reversed=True), "p19")
+
+    @patch('inaturalist.pyinaturalist')
+    def test_count_observations(self, mock_pyinaturalist):
+        mock_pyinaturalist.get_observations.return_value = {
+            "total_results": 11
+        }
+        self.assertEqual(count_observerations(user_id='bob1'), 11)
+        mock_pyinaturalist.get_observations.assert_called_with(user_id='bob1', count_only=True)
+
+    @patch('inaturalist.pyinaturalist')
+    def test_get_observations(self, mock_pyinaturalist):
+        mock_pyinaturalist.get_observations.return_value = {
+            "total_results": 1,
+            "results": [{ "id": 1}]
+        }
+        items, count = get_observations(user_id="bob1", limit=None)
+        self.assertEqual(items, [{ "id": 1}])
+        self.assertEqual(count, 1)
+        mock_pyinaturalist.get_observations.assert_called_with(user_id='bob1', page='all')
+
+        items, count = get_observations(user_id="bob1", limit=2)
+        mock_pyinaturalist.get_observations.assert_called_with(user_id='bob1', per_page=2)
+        self.assertEqual(items, [{ "id": 1}])
+        self.assertEqual(count, 1)

--- a/andromeda/tests/test_main.py
+++ b/andromeda/tests/test_main.py
@@ -83,13 +83,14 @@ class TestDataset(unittest.TestCase):
         observations = [{"Image_Label": "p1"}]
         warnings = ["missing_lat_long"]
         mock_get_inaturalist_observations.return_value = Mock(
-            data=observations, warnings=warnings)
+            data=observations, warnings=warnings, total=1)
         client = app.test_client()
         result = client.get(f"/api/inaturalist/bob")
         self.assertEqual(result.status_code, 200)
         self.assertEqual(
             result.json,
             {
+                'total': 1,
                 "data": [{"Image_Label": "p1"}],
                 "user_id": "bob",
                 "warnings": ["missing_lat_long"],
@@ -117,7 +118,7 @@ class TestDataset(unittest.TestCase):
 
     @patch("main.get_inaturalist_observations")
     def test_get_inaturalist_xml(self, mock_get_inaturalist_observations):
-        mock_get_inaturalist_observations.return_value = Mock(data=[], warnings=[])
+        mock_get_inaturalist_observations.return_value = Mock(data=[], warnings=[], total=0)
         client = app.test_client()
         result = client.get(f"/api/inaturalist/bob?format=xml")
         self.assertEqual(result.status_code, 400)
@@ -125,19 +126,21 @@ class TestDataset(unittest.TestCase):
 
     @patch("main.get_inaturalist_observations")
     def test_get_inaturalist_add_rgb(self, mock_get_inaturalist_observations):
-        mock_get_inaturalist_observations.return_value = Mock(data=[], warnings=[])
+        mock_get_inaturalist_observations.return_value = Mock(data=[], warnings=[], total=0)
         client = app.test_client()
         result = client.get(f"/api/inaturalist/bob?format=json&add_sat_rgb_data=true")
         self.assertEqual(result.status_code, 200)
-        mock_get_inaturalist_observations.assert_called_with(user_id='bob', add_sat_rgb_data=True, add_landcover_data=False)
+        mock_get_inaturalist_observations.assert_called_with(user_id='bob', add_sat_rgb_data=True, 
+                                                             add_landcover_data=False, limit=None)
 
     @patch("main.get_inaturalist_observations")
     def test_get_inaturalist_add_landcover(self, mock_get_inaturalist_observations):
-        mock_get_inaturalist_observations.return_value = Mock(data=[], warnings=[])
+        mock_get_inaturalist_observations.return_value = Mock(data=[], warnings=[], total=0)
         client = app.test_client()
         result = client.get(f"/api/inaturalist/bob?format=json&add_landcover_data=true")
         self.assertEqual(result.status_code, 200)
-        mock_get_inaturalist_observations.assert_called_with(user_id='bob', add_sat_rgb_data=False, add_landcover_data=True)
+        mock_get_inaturalist_observations.assert_called_with(user_id='bob', add_sat_rgb_data=False, 
+                                                             add_landcover_data=True, limit=None)
 
     @patch("main.get_inaturalist_observations")
     def test_get_inaturalist_bad_observation(self, mock_get_inaturalist_observations):

--- a/andromeda/tests/test_satellitedata.py
+++ b/andromeda/tests/test_satellitedata.py
@@ -165,10 +165,14 @@ class TestSatelliteData(unittest.TestCase):
         self.assertEqual(observations.data[0].get("Number"), 444)
         self.assertEqual(observations.add_warning.called, False)
 
-    @patch("satellitedata.pd")
-    def test_add_satellite_landcover_data(self, mock_pd):
-        sat_df = sample_landcover_dataframe()
-        mock_pd.read_csv.return_value = sat_df
+    @patch("satellitedata.time")
+    @patch("satellitedata.get_landcoverage_classification")
+    def test_add_satellite_landcover_data(self, mock_get_lc_classification, mock_time):
+        mock_get_lc_classification.side_effect = [
+            {'A_small': 0.426},
+            {'A_small': 0.326},
+            {'A_small': 0.226},
+        ]
         observations = Mock(data=sample_observation_data())
         add_satellite_landcover_data(
             observations=observations,
@@ -176,10 +180,9 @@ class TestSatelliteData(unittest.TestCase):
             long_fieldname='Long')
         self.assertEqual(len(observations.data), 3)
         self.assertEqual(observations.data[0]["id"], "p1")
-        self.assertEqual(observations.data[0]["Number"], 111)
+        self.assertEqual(observations.data[0]["A_small"], 0.426)
         self.assertEqual(observations.data[1]["id"], "p2")
-        self.assertEqual(observations.data[1]["Number"], 222)
+        self.assertEqual(observations.data[1]["A_small"], 0.326)
         self.assertEqual(observations.data[2]["id"], "p3")
-        self.assertEqual(observations.data[2].get("Number"), 111)
+        self.assertEqual(observations.data[2]["A_small"], 0.226)
         self.assertEqual(observations.add_warning.called, False)
-        mock_pd.read_csv.assert_called_with(LANDCOVER_SAT_CONFIG.url)

--- a/datasets/satelliteData/quest-2023-RGB-customData.json
+++ b/datasets/satelliteData/quest-2023-RGB-customData.json
@@ -1,0 +1,12 @@
+{
+    "label": "Add RGB Satellite Data",
+    "note": "Note: The RGB satellite data is specific to the Princeton, NJ area, as it was developed for QUEST 2023.",
+    "column_prefix": "sat",
+    "fields": {
+        "LAT_NW": "sat_Lat-NW",
+        "LON_NW": "sat_Lon-NW",
+        "LAT_SE": "sat_Lat-SE",
+        "LON_SE": "sat_Lon-SE"
+    },
+    "url": "https://raw.githubusercontent.com/Imageomics/Andromeda/main/datasets/satelliteData/satRgbFinal4.csv"
+}


### PR DESCRIPTION
Replaces logic that relied on a hard coded CSV for landcover data
with logic that uses a CropSpace API to dynamically lookup landcover
data for each iNaturalist geocoordinate at two scales. Removes
UI for hard coded RGB calculations since this isn't generic
like the Landcover data.

Also adds a fix for running in dev mode.