### PR TITLE
Fix visualization navigation

### DIFF
--- a/andromeda-ui/backend/dataset.ts
+++ b/andromeda-ui/backend/dataset.ts
@@ -11,6 +11,13 @@ export async function uploadDataset(file: File) {
   });
 }
 
+export async function readDataset(datasetId: string) {
+  const url = apiURL("/dataset/" + datasetId);
+  const response = await fetch(url);
+  const text = await response.text()
+  return text;
+}
+
 export async function dimensionalReduction(
   dataset_id: string,
   weights: any,

--- a/andromeda-ui/backend/parseCSV.ts
+++ b/andromeda-ui/backend/parseCSV.ts
@@ -1,6 +1,6 @@
 import Papa from "papaparse";
 
-export async function parseCSVFile(file: File) {
+export async function parseCSVFile(fileContent: string) {
   // Wrap Papa.parse in a promise to allow async/await usage
   const promise: any = new Promise((resolve, reject) => {
     var config = {
@@ -14,7 +14,7 @@ export async function parseCSVFile(file: File) {
         reject(error);
       },
     };
-    Papa.parse(file, config);
+    Papa.parse(fileContent, config);
   });
   return await promise;
 }

--- a/andromeda-ui/components/CSVFilename.tsx
+++ b/andromeda-ui/components/CSVFilename.tsx
@@ -1,0 +1,10 @@
+interface CSVFilenameProps {
+    name: string;
+}
+
+export function CSVFilename(props: CSVFilenameProps) {
+    return <div>
+        <span className="text-md font-medium">CSV file:&nbsp;</span>
+        <span>{props.name}</span>
+    </div>
+}

--- a/andromeda-ui/components/ConfigureDataset.tsx
+++ b/andromeda-ui/components/ConfigureDataset.tsx
@@ -4,6 +4,7 @@ import ColoredButton from './ColoredButton';
 import { groupColumnsByType } from "../backend/parseCSV";
 
 interface ConfigureDatasetProps {
+    datasetName: string
     columnDetails: any;
     columnSettings: any;
     setColumnSettings: any;
@@ -12,7 +13,7 @@ interface ConfigureDatasetProps {
 }
 
 export default function ConfigureDataset(props: ConfigureDatasetProps) {
-    const { columnDetails, columnSettings, setColumnSettings, visualizeData, onClickBack } = props;
+    const { datasetName, columnDetails, columnSettings, setColumnSettings, visualizeData, onClickBack } = props;
     function setLabelColumnName(value: string) {
         setColumnSettings({ ...columnSettings, label: value })
     }
@@ -57,6 +58,10 @@ export default function ConfigureDataset(props: ConfigureDatasetProps) {
 
     return <div>
         <h2 className="text-xl mb-2 font-bold">Configure Visualization</h2>
+        <div>
+            <div className="text-md font-medium">CSV file</div>
+            <div className="ml-3">{datasetName}</div>
+        </div>
         <div>
             <SimpleSelect
                 label="Label"

--- a/andromeda-ui/components/SelectColumnsList.tsx
+++ b/andromeda-ui/components/SelectColumnsList.tsx
@@ -19,7 +19,6 @@ export default function SelectColumnsList(props: SelectColumnsListrProps) {
     const { columns, selectedColumns, changeSelectedColumn } = props
     const groupedItems = groupItems(columns, CHECKBOXES_PER_ROW)
     const columnTableRows = groupedItems.map((columnNamesSubset: string[], idx: number) => {
-        console.log(idx, columnNamesSubset);
         const checkboxes: any = columnNamesSubset.map((x) => {
             const name = "select_column_" + x;
             return <td key={x} className="px-2 whitespace-nowrap">

--- a/andromeda-ui/components/UploadFile.tsx
+++ b/andromeda-ui/components/UploadFile.tsx
@@ -4,12 +4,10 @@ import ColoredButton from './ColoredButton';
 
 interface UploadFileProps {
     uploadFile: any;
-    showUploadButton: boolean;
-    selectedFileChanged: any;
 }
 
 export default function UploadFile(props: UploadFileProps) {
-    const { uploadFile, showUploadButton, selectedFileChanged } = props;
+    const { uploadFile } = props;
     const [selectedFile, setSelectedFile] = useState<File>();
 
     async function onChangeSelectedFile(event: React.ChangeEvent<HTMLInputElement>) {
@@ -17,7 +15,6 @@ export default function UploadFile(props: UploadFileProps) {
         const selectedFiles = files as FileList;
         if (selectedFiles && selectedFiles.length > 0) {
             setSelectedFile(selectedFiles[0]);
-            selectedFileChanged();
         } else {
             setSelectedFile(undefined);
         }
@@ -29,16 +26,6 @@ export default function UploadFile(props: UploadFileProps) {
         } else {
             showError("File must be selected first.");
         }
-    }
-
-    let uploadButton = null;
-    if (showUploadButton) {
-        uploadButton = <ColoredButton
-            label="Upload File"
-            onClick={onClickUploadFile}
-            disabled={selectedFile === undefined}
-            color="blue"
-        />
     }
 
     return <>
@@ -55,6 +42,11 @@ export default function UploadFile(props: UploadFileProps) {
                 accept=".csv"
                 id="formFile" />
         </div>
-        {uploadButton}
+        <ColoredButton
+            label="Upload File"
+            onClick={onClickUploadFile}
+            disabled={selectedFile === undefined}
+            color="blue"
+        />
     </>
 }

--- a/andromeda-ui/pages/dataset/[dataset]/index.tsx
+++ b/andromeda-ui/pages/dataset/[dataset]/index.tsx
@@ -1,0 +1,94 @@
+import { useRouter } from 'next/router'
+import React, { useState, useEffect } from 'react';
+import { getColumnConfig, readDataset } from "@/backend/dataset";
+import ConfigureDataset from "@/components/ConfigureDataset";
+import TitleBar from "@/components/TitleBar";
+import Main from "@/components/Main";
+import { parseCSVFile, createColumnDetails, createColumnSettings } from "@/backend/parseCSV";
+import Spinner from '@/components/Spinner';
+import { makeUrlColumnSettings, configureURLQueryDict, UrlColumnSettings } from '@/util/router-utils'
+import { url } from 'inspector';
+
+
+export default function Home() {
+  const router = useRouter()
+  const [datasetID, setDatasetID] = useState<string>("");
+  const [datasetName, setDatasetName] = useState<string>("");
+  const [columnDetails, setColumnDetails] = useState<any>();
+  const [columnSettings, setColumnSettings] = useState<any>();
+
+  useEffect(() => {
+    let urlColumnSettings = makeUrlColumnSettings(router);
+    console.log(urlColumnSettings);
+    if (urlColumnSettings.datasetID) {
+      applyURLSettings(urlColumnSettings);
+    }
+  }, [router.query.dataset]);
+
+  async function applyURLSettings(urlColumnSettings: UrlColumnSettings) {
+    const datasetContent = await readDataset(urlColumnSettings.datasetID);
+    const rows = await parseCSVFile(datasetContent);
+    const details = createColumnDetails(rows);
+    const columnConfig = await getColumnConfig();
+    const settings = createColumnSettings(details, columnConfig);
+    console.log(settings);
+    if (urlColumnSettings.label) {
+      settings.label = urlColumnSettings.label;
+    }
+    if (urlColumnSettings.url) {
+      settings.url = urlColumnSettings.url;
+    }
+    if (urlColumnSettings.selected.length > 0) {
+      settings.selected = urlColumnSettings.selected;
+    }
+    setDatasetID(urlColumnSettings.datasetID);
+    setColumnDetails(details);
+    setColumnSettings(settings);
+    setDatasetName(urlColumnSettings.datasetName);
+  }
+
+  function visualizeData() {
+    if (datasetID) {
+      // update current URL so back button will load the proper settings
+      router.replace({
+          pathname: `/dataset/${datasetID}`,
+          query: configureURLQueryDict(datasetName, columnSettings.label,
+            columnSettings.url, columnSettings.selected)
+      });
+      // push visualization page
+      router.push({
+        pathname: `/dataset/${datasetID}/visualize`,
+        query: configureURLQueryDict(datasetName, columnSettings.label,
+          columnSettings.url, columnSettings.selected)
+    });
+    }
+  }
+
+  function onClickBack() {
+    router.back();
+  }
+
+  let content = <Spinner />;
+  console.log(datasetID);
+  console.log(datasetName);
+  if (datasetID && datasetName) {
+    content = <ConfigureDataset
+      datasetName={datasetName}
+      columnDetails={columnDetails}
+      columnSettings={columnSettings}
+      setColumnSettings={setColumnSettings}
+      visualizeData={visualizeData}
+      onClickBack={onClickBack}
+    />;
+  }
+  return (
+    <>
+      <TitleBar selected="/" />
+      <Main>
+        <div>
+          {content}
+        </div>
+      </Main>
+    </>
+  )
+}

--- a/andromeda-ui/pages/dataset/[dataset]/visualize/index.tsx
+++ b/andromeda-ui/pages/dataset/[dataset]/visualize/index.tsx
@@ -1,0 +1,114 @@
+import dynamic from 'next/dynamic'
+import { useRouter } from 'next/router'
+import React, { useState, useEffect } from 'react';
+import TitleBar from "@/components/TitleBar";
+import Main from "@/components/Main";
+import { showError } from "@/util/toast";
+const DataExplorer = dynamic(() => import("@/components/DataExplorer"), {
+  ssr: false,
+});
+import { dimensionalReduction, reverseDimensionalReduction, calculatePointScaling} from "@/backend/dataset";
+import Spinner from '@/components/Spinner';
+import { CSVFilename } from '@/components/CSVFilename';
+import { makeUrlColumnSettings, configureURLQueryDict, UrlColumnSettings } from '@/util/router-utils'
+
+const DEFAULT_POINT_SCALING = 1.0;
+
+
+export default function Home() {
+  const router = useRouter()
+
+  const [datasetID, setDatasetID] = useState<string>();
+  const [datasetName, setDatasetName] = useState<string>("");
+  const [imageData, setImageData] = useState<any[]>();
+  const [weightData, setWeightData] = useState<any[]>();
+  const [columnSettings, setColumnSettings] = useState<any>();
+  const [pointScaling, setPointScaling] = useState<number>(DEFAULT_POINT_SCALING);
+
+  useEffect(() => {
+    let urlColumnSettings = makeUrlColumnSettings(router);
+    if (urlColumnSettings.datasetID) {
+      applyURLSettings(urlColumnSettings);
+    }
+  }, [router.query.dataset, router.query.name]);
+
+  useEffect(() => {
+    if (datasetID && columnSettings) {
+      const initialWeights = { all: 1.0 / columnSettings.selected.length };
+      performDimensionalReduction(datasetID, initialWeights);
+    }
+  }, [datasetID, columnSettings]);
+
+  async function applyURLSettings(urlColumnSettings: UrlColumnSettings) {
+    setDatasetName(urlColumnSettings.datasetName);
+    setDatasetID(urlColumnSettings.datasetID);
+    setColumnSettings(urlColumnSettings);
+    setImageData(undefined);
+    setWeightData(undefined);
+  }
+
+  async function performDimensionalReduction(id: string, weights: any) {
+    try {
+      console.log(weights);
+      console.log(columnSettings);
+      const result = await dimensionalReduction(id, weights, columnSettings)
+      setDatasetID(id);
+      setPointScaling(calculatePointScaling(result.images));
+      setImageData(result.images);
+      setWeightData(result.weights);
+      return result;
+    } catch (error: any) {
+      console.log(error);
+      showError(error.message);
+    }
+    return null;
+  }
+
+  async function performReverseDimensionalReduction(id: string, movedPositions: any[]) {
+    try {
+      const result = await reverseDimensionalReduction(id, movedPositions, columnSettings)
+      setWeightData(result.weights);
+      return result;
+    } catch (error: any) {
+      console.log(error);
+      showError(error.message);
+    }
+    return null;
+  }
+  function onDataExplorerClickBack() {
+    router.back()
+  }
+
+  let content = <Spinner />;;
+  if (datasetID && imageData) {
+    content =
+      <>
+        <DataExplorer
+          datasetID={datasetID}
+          images={imageData}
+          weights={weightData}
+          setImageData={setImageData}
+          drFunc={performDimensionalReduction}
+          rdrFunc={performReverseDimensionalReduction}
+          columnSettings={columnSettings}
+          onClickBack={onDataExplorerClickBack}
+          pointScaling={pointScaling}
+          setPointScaling={setPointScaling}
+        />
+      </>;
+  }
+
+  return (
+    <>
+      <TitleBar selected="/" />
+      <Main>
+        <div>
+          <CSVFilename name={datasetName} />
+        </div>
+        <div>
+          {content}
+        </div>
+      </Main>
+    </>
+  )
+}

--- a/andromeda-ui/pages/dataset/[dataset]/visualize/index.tsx
+++ b/andromeda-ui/pages/dataset/[dataset]/visualize/index.tsx
@@ -18,7 +18,7 @@ const DEFAULT_POINT_SCALING = 1.0;
 export default function Home() {
   const router = useRouter()
 
-  const [datasetID, setDatasetID] = useState<string>();
+  const [datasetID, setDatasetID] = useState<string>("");
   const [datasetName, setDatasetName] = useState<string>("");
   const [imageData, setImageData] = useState<any[]>();
   const [weightData, setWeightData] = useState<any[]>();

--- a/andromeda-ui/util/router-utils.ts
+++ b/andromeda-ui/util/router-utils.ts
@@ -1,0 +1,51 @@
+import { NextRouter } from 'next/router'
+
+export interface UrlColumnSettings {
+    datasetID: string;
+    datasetName: string;
+    label: string;
+    url: string;
+    selected: string[];
+}
+
+export function ensureIsString(item: any) : string {
+    if (isNonEmptyString(item)) {
+        return item
+    }
+    return "";
+}
+
+export function isNonEmptyString(item: any): boolean {
+    return item && typeof item === "string";
+}
+
+function ensureIsArray(item: any) : string[] {
+    if (item && Array.isArray(item)) {
+        return item
+    }
+    return [];
+}
+
+export function makeUrlColumnSettings(router: NextRouter) : UrlColumnSettings {
+    let datasetID = ensureIsString(router.query.dataset);
+    let datasetName = ensureIsString(router.query.name);
+    if (!datasetName) {
+        datasetName = datasetID;
+    }
+    return {
+        datasetID: datasetID,
+        datasetName: datasetName,
+        label: ensureIsString(router.query.label),
+        url: ensureIsString(router.query.url),
+        selected: ensureIsArray(router.query.selected),
+    };
+}
+
+export function configureURLQueryDict(datasetName: string, label: string, url: string, selected: string[]) {
+    return {
+        name: datasetName,
+        label: label,
+        url: url,
+        selected: selected
+    }
+}


### PR DESCRIPTION
Changes visualization pages to support browser button navigation. Users can now more easily change the column settings for a visualized dataset by clicking the back browser button.

Breaks up the large visualization page (index.tsx) into three pages:
- Uploading a CSV
- Configuring the visualization
- Explore the visualization

Fixes #81