### PR TITLE
Highlight weights on hover

### DIFF
--- a/andromeda-ui/components/DataExplorer.tsx
+++ b/andromeda-ui/components/DataExplorer.tsx
@@ -19,6 +19,7 @@ interface DataExplorerProps {
     weights: any | undefined;
     datasetID: string | undefined;
     columnSettings: any;
+    columnDetails: any;
     drFunc: any;
     rdrFunc: any;
     onClickBack: any;
@@ -27,7 +28,7 @@ interface DataExplorerProps {
 
 export default function DataExplorer(props: DataExplorerProps) {
     const { images, setImageData, pointScaling, setPointScaling,
-        weights, datasetID, columnSettings,
+        weights, datasetID, columnSettings, columnDetails,
         drFunc, rdrFunc, onClickBack } = props;
     const [imageSize, setImageSize] = useState<number>(DEFAULT_IMAGE_SIZE);
     const [showLabel, setShowLabel] = useState<boolean>(true);
@@ -35,6 +36,7 @@ export default function DataExplorer(props: DataExplorerProps) {
     const [sliderWeights, setSliderWeights] = useState<any>(weights);
     const [working, setWorking] = useState<boolean>(false);
     const stageRef = useRef<any>(null);
+    const [highlightImageKey, setHighlightImageKey] = useState<string>();
 
     function onImageMoved(x: number, y: number, label: string) {
         if (images) {
@@ -55,9 +57,15 @@ export default function DataExplorer(props: DataExplorerProps) {
     }
 
     if (weights) {
+        let highlightValues: {[key:string]: number} = {}
+        if (highlightImageKey) {
+            highlightValues = images.find((x) => x.label == highlightImageKey).values;
+        }
+
         weightControls = Object.keys(weights).map(key => <WeightSlider
             key={key}
             id={key}
+            highlight={highlightValues[key]}
             weights={sliderWeights}
             onChange={(evt: any) => onChangeWeight(key, parseFloat(evt.target.value))} />);
     }
@@ -128,6 +136,7 @@ export default function DataExplorer(props: DataExplorerProps) {
                     showImage={showImage}
                     onImageMoved={onImageMoved}
                     images={images}
+                    setHighlightImageKey={setHighlightImageKey}
                 />
                 <div className="flex gap-2 my-2 mr-2">
                     <ColoredButton

--- a/andromeda-ui/components/ImageGrid.tsx
+++ b/andromeda-ui/components/ImageGrid.tsx
@@ -12,6 +12,7 @@ interface ImageGridProps {
     showLabel: boolean;
     showImage: boolean;
     onImageMoved: any;
+    setHighlightImageKey: any;
     images: any[];
 }
 
@@ -55,10 +56,13 @@ export default function ImageGrid(props: ImageGridProps) {
     const { stageRef, size, imageSize, pointScaling, showLabel, showImage, images } = props;
     function onMouseEnter(evt: any) {
         stageRef.current.container().style.cursor = 'move';
+        const dataLabel = evt.currentTarget.attrs["data-label"];
+        props.setHighlightImageKey(dataLabel);
     }
 
     function onMouseLeave(evt: any) {
         stageRef.current.container().style.cursor = 'grab';
+        props.setHighlightImageKey(undefined);
     }
 
     const imageControls = images.map(item => createImage(

--- a/andromeda-ui/components/WeightSlider.tsx
+++ b/andromeda-ui/components/WeightSlider.tsx
@@ -1,24 +1,37 @@
 interface WeightSliderProps {
     id: string;
     weights: any;
+    highlight: number | undefined;
     onChange: any;
 }
 
-export default function WeightSlider({ id, weights, onChange }: WeightSliderProps) {
-    const value = weights[id];
+const SLIDER_WIDTH = 200;
 
+
+export default function WeightSlider({ id, weights, highlight, onChange }: WeightSliderProps) {
+    const value = weights[id];
+    let highlightDiv = null;
+    if (highlight !== undefined) {
+        const hintPosition = highlight * (SLIDER_WIDTH - 4);
+        highlightDiv = <div className="absolute left-2 top-1 inline w-1 bg-cyan-600 h-3" style={{"left": hintPosition + "px"}}>
+            &nbsp;
+        </div>;
+    }
     return <div key={id} className="flex flex-nowrap">
-        <input
-            type="range"
-            id={id}
-            name={id}
-            value={value}
-            onChange={onChange}
-            min="0.001"
-            max="0.999"
-            step="0.001"
-            className="w-60"
-        ></input>
+        <div className="relative">
+            <input
+                type="range"
+                id={id}
+                name={id}
+                value={value}
+                onChange={onChange}
+                min="0.001"
+                max="0.999"
+                step="0.001"
+                style={{"width": SLIDER_WIDTH + "px"}}
+            ></input>
+            {highlightDiv}
+        </div>
         &nbsp;
         <label htmlFor="volume">{id}</label>
     </div>

--- a/andromeda/tests/test_dataset.py
+++ b/andromeda/tests/test_dataset.py
@@ -53,9 +53,11 @@ class TestDataset(unittest.TestCase):
 
         self.assertEqual(weights.keys(), set(["R1", "B1", "G1"]))
         self.assertEqual(len(image_coordinates), 3)
-        self.assertEqual(image_coordinates[0].keys(), set(["x", "y", "label", "url"]))
+        self.assertEqual(image_coordinates[0].keys(), set(["x", "y", "label", "url", "values"]))
         self.assertEqual(image_coordinates[0]["label"], "p1")
         self.assertEqual(image_coordinates[0]["url"], "https://example.com/p1.jpg")
+        self.assertEqual(image_coordinates[0]["values"].keys(), set(["R1", "B1", "G1"]))
+        self.assertEqual(image_coordinates[0]["values"]["B1"], 0.2)
         self.assertEqual(image_coordinates[1]["url"], "")
 
     @patch('dataset.os')


### PR DESCRIPTION
Adds logic to show values for an observation when the user's mouse is over it. The values will be shown by a small square on the weight slider following an earlier convention.

The backend API now returns values for each observation scaled to a value between 0 and 1.

Fixes #62