### PR TITLE
Fix npm build and automate testing

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -1,0 +1,21 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+      - run: npm install
+        working-directory: ./andromeda-ui
+      - run: npm run build
+        working-directory: ./andromeda-ui
+      - run: npm run test
+        working-directory: ./andromeda-ui
+

--- a/andromeda-ui/components/DataExplorer.tsx
+++ b/andromeda-ui/components/DataExplorer.tsx
@@ -19,7 +19,6 @@ interface DataExplorerProps {
     weights: any | undefined;
     datasetID: string | undefined;
     columnSettings: any;
-    columnDetails: any;
     drFunc: any;
     rdrFunc: any;
     onClickBack: any;
@@ -28,7 +27,7 @@ interface DataExplorerProps {
 
 export default function DataExplorer(props: DataExplorerProps) {
     const { images, setImageData, pointScaling, setPointScaling,
-        weights, datasetID, columnSettings, columnDetails,
+        weights, datasetID, columnSettings,
         drFunc, rdrFunc, onClickBack } = props;
     const [imageSize, setImageSize] = useState<number>(DEFAULT_IMAGE_SIZE);
     const [showLabel, setShowLabel] = useState<boolean>(true);

--- a/andromeda-ui/tests/backend/observations.test.ts
+++ b/andromeda-ui/tests/backend/observations.test.ts
@@ -1,5 +1,4 @@
 import { makeObservationURL, fetchObservations } from "../../backend/observations";
-import fetchMock from 'fetch-mock';
 
 jest.mock('next/config', () => () => ({
     publicRuntimeConfig: {
@@ -33,8 +32,11 @@ test("fetchObservations returns JSON result of observations", async () => {
         "data": [{"label": "p1"}],
         "warnings": ["some_warning"]        
     }
-    fetchMock.get('https://example.com/api/inaturalist/bob?format=json&add_sat_rgb_data=false&add_landcover_data=false', payload);
-    const results = await fetchObservations("bob", false, false);
+    jest.spyOn(global, "fetch").mockImplementation(
+        jest.fn(
+          () => Promise.resolve({ ok: true, json: () => Promise.resolve(payload),
+        }),
+      ) as jest.Mock );
+    const results = await fetchObservations("bob", false, false, 10);
     expect(results).toStrictEqual(payload);
-    fetchMock.restore();
 });

--- a/andromeda-ui/tests/backend/util.test.ts
+++ b/andromeda-ui/tests/backend/util.test.ts
@@ -1,5 +1,4 @@
 import { apiURL, fetch_json } from "../../backend/util";
-import fetchMock from 'fetch-mock';
 
 jest.mock('next/config', () => () => ({
     publicRuntimeConfig: {
@@ -14,9 +13,11 @@ test("apiURL creates a URL for a prefix", () => {
 
 test("fetch_json calls fetch", async () => {
     const url = "https://example.com/api/dataset/123";
-    fetchMock.get(url, {
-        "data": 123
-    });
+    jest.spyOn(global, "fetch").mockImplementation(
+        jest.fn(
+          () => Promise.resolve({ ok: true, json: () => Promise.resolve({"data": 123}),
+        }),
+      ) as jest.Mock );
     const result = await fetch_json(url, { method: "GET"});
     expect(result).toStrictEqual({
         "data": 123


### PR DESCRIPTION
Adds a Github Action to build and test the Typescript code. One test was failing because of a new argument.
Other tests had problems with importing fetch-mock. I used a jest-based solution to avoid fetch-mock.

Fixes #86