### PR TITLE
Fix React API URL

### DIFF
--- a/andromeda-ui/next.config.js
+++ b/andromeda-ui/next.config.js
@@ -2,7 +2,7 @@
 const { PHASE_DEVELOPMENT_SERVER } = require("next/constants");
 
 module.exports = (phase, { defaultConfig }) => {
-  let apiURL = "api";
+  let apiURL = "/api";
   if (phase === PHASE_DEVELOPMENT_SERVER) {
     apiURL = "http://127.0.0.1:5000/api";
   }


### PR DESCRIPTION
Use absolute path for the API URL to fix a problem where the relative path was wrong for nested pages.

Fixes #88