### PR TITLE
Add DOI & prep for next release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,7 +21,7 @@ authors:
   given-names: "Leanna"
   orcid: "https://orcid.org/0009-0003-2848-4131"
 cff-version: 1.2.0
-date-released: "2024-07-02"
+date-released: "2024-07-03"
 identifiers:
   - doi: "10.5281/zenodo.12107162"
   - description: "The GitHub release URL of tag 1.3.0."

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,14 +21,15 @@ authors:
   given-names: "Leanna"
   orcid: "https://orcid.org/0009-0003-2848-4131"
 cff-version: 1.2.0
-date-released: "2024-02-16"
+date-released: "2024-07-02"
 identifiers:
-  - description: "The GitHub release URL of tag 1.2.2."
+  - doi: "10.5281/zenodo.12107162"
+  - description: "The GitHub release URL of tag 1.3.0."
     type: url
-    value: "https://github.com/Imageomics/Andromeda/releases/tag/1.2.2"
+    value: "https://github.com/Imageomics/Andromeda/releases/tag/1.3.0"
   - description: "The GitHub URL of the commit tagged with 1.2.2."
     type: url
-    value: "https://github.com/Imageomics/Andromeda/tree/2fb1598ced144c298f829e1173f1ca9467845a5f"
+    value: "https://github.com/Imageomics/Andromeda/tree/2fb1598ced144c298f829e1173f1ca9467845a5f" #Update on release
 keywords:
   - "multi-dimensional scaling"
   - "MDS"
@@ -46,7 +47,7 @@ license: MIT
 message: "If you use this software, please cite it using these metadata."
 repository-code: "https://github.com/Imageomics/Andromeda"
 title: "Andromeda"
-version: 1.2.2
+version: 1.3.0
 references:
   # Papers covering the algorithm and conecpt of Andromeda (original introduction, followed by newer work)
   - authors:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Andromeda
+# Andromeda  [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.12107162.svg)](https://zenodo.org/doi/10.5281/zenodo.12107162)
 Andromeda allows users to visualize high dimensional data in a 2-dimensional plot using weighted multidimensional scaling. Through the interactive interface users can explore the relationships within their data by adjusting the variable weights and viewing an updated plot.  Alternatively users can arrange the items  in the plot so that Andromeda can determine new variable weights and create a new projection. 
 
 This package also includes a page to fetch data from iNaturalist observations and pair them with satellite RGB and landcover data for analysis with Andromeda. 


### PR DESCRIPTION
Adds [general DOI](https://doi.org/10.5281/zenodo.12107162) from Zenodo to `CITATION.cff` and `README`. Also sets update for next version in citation file. I'll update the release date when it's approved. Can set release "show points with labels".