### PR TITLE
Add note directing user to GitHub for source code and guides

### DIFF
--- a/andromeda-ui/components/SourceNote.tsx
+++ b/andromeda-ui/components/SourceNote.tsx
@@ -1,0 +1,16 @@
+import Anchor from "../components/Anchor";
+
+export default function SourceNote() {
+    return <p className="text-sm mt-4 max-w-prose" >
+        <b>Note: </b>
+        All source code is available on the&nbsp;
+        <Anchor href="https://github.com/Imageomics/Andromeda" target="_blank">Andromeda GitHub repository</Anchor>.
+        <br></br>
+        User and developer guides are available on the&nbsp;
+        <Anchor href="https://github.com/Imageomics/Andromeda/wiki" target="_blank">repository wiki</Anchor>,
+        &nbsp;and sample datasets can be found in the&nbsp;
+        <Anchor href="https://github.com/Imageomics/Andromeda/tree/main/datasets" target="_blank">
+        datasets directory
+        </Anchor>.
+    </p>
+}

--- a/andromeda-ui/components/UploadFile.tsx
+++ b/andromeda-ui/components/UploadFile.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { showError } from "../util/toast";
 import ColoredButton from './ColoredButton';
+import SourceNote from './SourceNote';
 
 interface UploadFileProps {
     uploadFile: any;
@@ -48,5 +49,8 @@ export default function UploadFile(props: UploadFileProps) {
             disabled={selectedFile === undefined}
             color="blue"
         />
-    </>
+        <div>
+            <SourceNote />
+        </div>
+    </>;
 }


### PR DESCRIPTION
We need a link back to the GitHub for our HF Andromeda instance. Users are most likely to see this on the home page, so I made the following addition. I believe it'll look a bit smaller on the HF instance, as I used the same code for the `latloncover` note (I did bold "Note"). URLs are purple since I've clicked on them (as set in our style).

![Screenshot 2024-07-16 at 3 00 11 PM](https://github.com/user-attachments/assets/b31e0714-722e-4a56-82a7-30015b5c5503)

Resolves issue #93.