### PR TITLE
Updates for version 1.3.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,7 +21,7 @@ authors:
   given-names: "Leanna"
   orcid: "https://orcid.org/0009-0003-2848-4131"
 cff-version: 1.2.0
-date-released: "2024-07-03"
+date-released: "2024-07-19"
 identifiers:
   - doi: "10.5281/zenodo.12107162"
   - description: "The GitHub release URL of tag 1.3.1."

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,12 +24,12 @@ cff-version: 1.2.0
 date-released: "2024-07-03"
 identifiers:
   - doi: "10.5281/zenodo.12107162"
-  - description: "The GitHub release URL of tag 1.3.0."
+  - description: "The GitHub release URL of tag 1.3.1."
     type: url
-    value: "https://github.com/Imageomics/Andromeda/releases/tag/1.3.0"
+    value: "https://github.com/Imageomics/Andromeda/releases/tag/1.3.1"
   - description: "The GitHub URL of the commit tagged with 1.3.0."
     type: url
-    value: "https://github.com/Imageomics/Andromeda/tree/b1f28e74c83d636443f60fa6a4ad27d4e81f31cd"
+    value: "https://github.com/Imageomics/Andromeda/tree/b1f28e74c83d636443f60fa6a4ad27d4e81f31cd" # Update on release
 keywords:
   - "multi-dimensional scaling"
   - "MDS"
@@ -47,7 +47,7 @@ license: MIT
 message: "If you use this software, please cite it using these metadata."
 repository-code: "https://github.com/Imageomics/Andromeda"
 title: "Andromeda"
-version: 1.3.0
+version: 1.3.1
 references:
   # Papers covering the algorithm and conecpt of Andromeda (original introduction, followed by newer work)
   - authors:


### PR DESCRIPTION
Updating the citation file for the next release (v1.3.1), which added directions pointing back to the GitHub repo to the homepage of the Andromeda app.